### PR TITLE
feat: Export workflow schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openworkflowspec/sdk",
-  "version": "1.0.3-alpha6",
+  "version": "1.0.3-alpha7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openworkflowspec/sdk",
-      "version": "1.0.3-alpha6",
+      "version": "1.0.3-alpha7",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openworkflowspec/sdk",
-  "version": "1.0.3-alpha6",
+  "version": "1.0.3-alpha7",
   "schemaVersion": "1.0.3",
   "supportedDslVersions": ">=1.0.0-0 <=1.0.3",
   "description": "Typescript SDK for Open Workflow Specification",

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * oUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import type { SchemaObject } from 'ajv';
+import workflowSchemaJson from './generated/schema/workflow.json';
+
+/**
+ * THE JSON Schema of the Open Workflow DSL - the exact document that {@link validate} uses to validate workflows.
+ * Versioned by the specification not by this package: $id and package.json schemaVersion bit have DSL version it was generated from.
+ **/
+
+export const workflowSchema: SchemaObject = workflowSchemaJson;

--- a/src/open-workflow-sdk.ts
+++ b/src/open-workflow-sdk.ts
@@ -5,3 +5,4 @@ export * from './lib/errors';
 export * from './lib/validation';
 export * from './lib/graph-builder';
 export * from './lib/mermaid-converter';
+export * from './lib/schema';

--- a/tests/validation/schema.spec.ts
+++ b/tests/validation/schema.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * oUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { workflowSchema } from '../../src/lib/schema';
+import { schemaVersion } from '../../package.json';
+
+describe('workflowSchema', () => {
+  it('it is the same schema the validatior enforces', () => {
+    expect(workflowSchema.$id).toBe(`https://open-workflow-specification.org/schemas/${schemaVersion}/workflow.json`);
+  });
+
+  it('it carries the definitions consumers navigate by (smoke test)', () => {
+    expect(workflowSchema.$defs?.task).toBeDefined();
+    expect(workflowSchema.$defs?.taskList).toBeDefined();
+    expect(workflowSchema.$defs?.callTask).toBeDefined();
+  });
+});


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes https://github.com/open-workflow-specification/sdk-typescript/issues/302

Export workflow schema

**Special notes for reviewers**:

A workflow document only records what someone already wrote. The set of available options - which properties a task accepts, which are required, the enum values etc exist only in the schema. So any tool that builds an editing form, drives autocomplete, generates documentation, or explains a validation error needs the schema, and needs the same one the validator enforces.

