### PR TITLE
Fix serialization to YAML, add option to disable validation, improve test coverage

### DIFF
--- a/src/lib/generated/classes/workflow.ts
+++ b/src/lib/generated/classes/workflow.ts
@@ -115,7 +115,6 @@ export class Workflow extends ObjectHydrator<Specification.Workflow> {
     if (format === 'json') {
       return json;
     }
-    // js-yaml only handles plain objects
     return yaml.dump(JSON.parse(json));
   }
 

--- a/src/lib/generated/classes/workflow.ts
+++ b/src/lib/generated/classes/workflow.ts
@@ -104,14 +104,19 @@ export class Workflow extends ObjectHydrator<Specification.Workflow> {
     model: Partial<WorkflowIntersection>,
     format: 'yaml' | 'json' = 'yaml',
     normalize: boolean = true,
+    validate: boolean = true,
   ): string {
     const workflow = new Workflow(model);
-    workflow.validate();
-    const normalized = normalize ? workflow.normalize() : workflow;
-    if (format === 'json') {
-      return JSON.stringify(normalized);
+    if (validate) {
+      workflow.validate();
     }
-    return yaml.dump(normalized);
+    const normalized = normalize ? workflow.normalize() : workflow;
+    const json = JSON.stringify(normalized);
+    if (format === 'json') {
+      return json;
+    }
+    // js-yaml only handles plain objects
+    return yaml.dump(JSON.parse(json));
   }
 
   static toGraph(model: Partial<WorkflowIntersection>, options?: GraphBuildOptions): Graph {
@@ -126,10 +131,11 @@ export class Workflow extends ObjectHydrator<Specification.Workflow> {
    * Serializes the workflow to YAML or JSON
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
+   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true): string {
-    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize);
+  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true, validate: boolean = true): string {
+    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize, validate);
   }
 
   /**
@@ -163,9 +169,15 @@ export const _Workflow = Workflow as WorkflowConstructor & {
    * @param workflow The workflow to serialize
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
+   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(workflow: Partial<WorkflowIntersection>, format?: 'yaml' | 'json', normalize?: boolean): string;
+  serialize(
+    workflow: Partial<WorkflowIntersection>,
+    format?: 'yaml' | 'json',
+    normalize?: boolean,
+    validate?: boolean,
+  ): string;
 
   /**
    * Creates a directed graph representation of the provided workflow

--- a/tests/serialization/workflow-serialization.spec.ts
+++ b/tests/serialization/workflow-serialization.spec.ts
@@ -17,6 +17,7 @@
 
 import { Specification } from '../../src/lib/generated/definitions';
 import { Classes } from '../../src/lib/generated/classes';
+import { SchemaValidationError } from '../../src/lib/errors';
 
 import { schemaVersion } from '../../package.json';
 import { documentBuilder, setTaskBuilder, taskListBuilder, workflowBuilder } from '../../src';
@@ -107,5 +108,142 @@ describe('Workflow (de)serialization', () => {
     const expected = JSON.stringify(workflow);
     const serialized = Classes.Workflow.serialize(workflow, 'json');
     expect(serialized).toEqual(expected);
+  });
+});
+
+describe('Workflow serialization - YAML format', () => {
+  const data: Specification.Workflow = {
+    document: {
+      dsl: schemaVersion,
+      name: 'test',
+      version: '1.0.0',
+      namespace: 'default',
+    },
+    do: [
+      {
+        step1: {
+          set: {
+            foo: 'bar',
+          },
+        },
+      },
+    ],
+  };
+
+  it('should serialize as YAML by default from static method', () => {
+    const workflow = new Classes.Workflow(data);
+    const serialized = Classes.Workflow.serialize(workflow);
+    expect(typeof serialized).toBe('string');
+    expect(serialized).toMatch(/document:/);
+    expect(serialized).toMatch(/foo: bar/);
+  });
+
+  it('should serialize as YAML by default from instance method', () => {
+    const workflow = new Classes.Workflow(data);
+    const serialized = workflow.serialize();
+    expect(typeof serialized).toBe('string');
+    expect(serialized).toMatch(/document:/);
+    expect(serialized).toMatch(/foo: bar/);
+  });
+
+  it('should serialize as YAML when format is explicitly set to yaml', () => {
+    const workflow = new Classes.Workflow(data);
+    const serialized = Classes.Workflow.serialize(workflow, 'yaml');
+    expect(typeof serialized).toBe('string');
+    expect(serialized).toMatch(/document:/);
+  });
+});
+
+describe('Workflow serialization - normalize flag', () => {
+  const data: Specification.Workflow = {
+    document: {
+      dsl: schemaVersion,
+      name: 'test',
+      version: '1.0.0',
+      namespace: 'default',
+    },
+    do: [
+      {
+        step1: {
+          set: {
+            foo: 'bar',
+          },
+        },
+      },
+    ],
+  };
+
+  it('should serialize without normalizing when normalize is false (static method)', () => {
+    const workflow = new Classes.Workflow(data);
+    const serialized = Classes.Workflow.serialize(workflow, 'json', false);
+    const parsed = JSON.parse(serialized);
+    expect(parsed).toMatchObject(data);
+  });
+
+  it('should serialize without normalizing when normalize is false (instance method)', () => {
+    const workflow = new Classes.Workflow(data);
+    const serialized = workflow.serialize('json', false);
+    const parsed = JSON.parse(serialized);
+    expect(parsed).toMatchObject(data);
+  });
+});
+
+describe('Workflow serialization - validate flag', () => {
+  const validData: Specification.Workflow = {
+    document: {
+      dsl: schemaVersion,
+      name: 'test',
+      version: '1.0.0',
+      namespace: 'default',
+    },
+    do: [
+      {
+        step1: {
+          set: {
+            foo: 'bar',
+          },
+        },
+      },
+    ],
+  };
+
+  const invalidData = {
+    document: {
+      dsl: schemaVersion,
+      name: 'test',
+      version: '1.0.0',
+      namespace: 'default',
+    },
+    // missing required 'do'
+  } as unknown as Specification.Workflow;
+
+  it('should throw a SchemaValidationError when serializing an invalid workflow (static method)', () => {
+    const workflow = new Classes.Workflow(invalidData);
+    expect(() => Classes.Workflow.serialize(workflow, 'json')).toThrow(SchemaValidationError);
+  });
+
+  it('should throw a SchemaValidationError when serializing an invalid workflow (instance method)', () => {
+    const workflow = new Classes.Workflow(invalidData);
+    expect(() => workflow.serialize('json')).toThrow(SchemaValidationError);
+  });
+
+  it('should not throw when validate is false even for an invalid workflow (static method)', () => {
+    const workflow = new Classes.Workflow(invalidData);
+    expect(() => Classes.Workflow.serialize(workflow, 'json', true, false)).not.toThrow();
+  });
+
+  it('should not throw when validate is false even for an invalid workflow (instance method)', () => {
+    const workflow = new Classes.Workflow(invalidData);
+    expect(() => workflow.serialize('json', true, false)).not.toThrow();
+  });
+
+  it('should serialize a valid workflow without errors when validate is true (static method)', () => {
+    const workflow = new Classes.Workflow(validData);
+    expect(() => Classes.Workflow.serialize(workflow, 'json', true, true)).not.toThrow();
+  });
+
+  it('should serialize a valid workflow without errors when validate is true (instance method)', () => {
+    const workflow = new Classes.Workflow(validData);
+    expect(() => workflow.serialize('json', true, true)).not.toThrow();
   });
 });

--- a/tools/4_generate-classes.ts
+++ b/tools/4_generate-classes.ts
@@ -122,14 +122,18 @@ export class ${name} extends ${baseClass ? '_' + baseClass : `ObjectHydrator<Spe
     model: Partial<WorkflowIntersection>,
     format: 'yaml' | 'json' = 'yaml',
     normalize: boolean = true,
+    validate: boolean = true,
   ): string {
     const workflow = new Workflow(model);
-    workflow.validate();
-    const normalized = normalize ? workflow.normalize() : workflow;
-    if (format === 'json') {
-      return JSON.stringify(normalized);
+    if (validate) {
+      workflow.validate();
     }
-    return yaml.dump(normalized);
+    const normalized = normalize ? workflow.normalize() : workflow;
+    const json = JSON.stringify(normalized);
+    if (format === 'json') {
+      return json;
+    }
+    return yaml.dump(JSON.parse(json));
   }
 
   static toGraph(model: Partial<WorkflowIntersection>, options?: GraphBuildOptions): Graph {
@@ -144,10 +148,11 @@ export class ${name} extends ${baseClass ? '_' + baseClass : `ObjectHydrator<Spe
    * Serializes the workflow to YAML or JSON
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
+   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true): string {
-    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize);
+  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true, validate: boolean = true): string {
+    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize, validate);
   }
 
   /**
@@ -185,9 +190,10 @@ export const _${name} = ${name} as ${name}Constructor${
    * @param workflow The workflow to serialize
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
+   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(workflow: Partial<WorkflowIntersection>, format?: 'yaml' | 'json', normalize?: boolean): string;
+  serialize(workflow: Partial<WorkflowIntersection>, format?: 'yaml' | 'json', normalize?: boolean, validate?: boolean): string;
 
   /**
    * Creates a directed graph representation of the provided workflow


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Closes https://github.com/open-workflow-specification/sdk-typescript/issues/306
Closes https://github.com/open-workflow-specification/editor/issues/338

The `js-yaml` library does not support classes, only plain objects. This was causing issues when a workflow instance is serialized to YAML.

**Additional information (if needed):**
Changes in this PR:
- Fixed YAML serialization by reusing the JSON serialization to produce a plain workflow object.
- Added an optional parameter to disable validation during the serialization process. In editing scenarios, a workflow may be valid but have validation errors because it is a work in progress.
- Added YAML serialization test coverage.