### PR TITLE
fix: restore YAML serialization broken by the js-yaml v5 upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openworkflowspec/sdk",
-  "version": "1.0.3-alpha7",
+  "version": "1.0.3-alpha8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openworkflowspec/sdk",
-      "version": "1.0.3-alpha7",
+      "version": "1.0.3-alpha8",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.20.0",
@@ -17,7 +17,6 @@
       "devDependencies": {
         "@apidevtools/json-schema-ref-parser": "^15.3.1",
         "@arethetypeswrong/cli": "^0.18.2",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^26.1.1",
         "@types/semver": "^7.7.1",
         "@types/yargs": "^17.0.32",
@@ -1695,12 +1694,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openworkflowspec/sdk",
-  "version": "1.0.3-alpha7",
+  "version": "1.0.3-alpha8",
   "schemaVersion": "1.0.3",
   "supportedDslVersions": ">=1.0.0-0 <=1.0.3",
   "description": "Typescript SDK for Open Workflow Specification",
@@ -84,10 +84,10 @@
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.3.1",
     "@arethetypeswrong/cli": "^0.18.2",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^26.1.1",
     "@types/semver": "^7.7.1",
     "@types/yargs": "^17.0.32",
+    "@typescript/native": "npm:typescript@^7.0.2",
     "http-server": "^14.1.1",
     "husky": "^9.1.7",
     "json-schema-to-typescript": "^15.0.4",
@@ -98,7 +98,6 @@
     "rimraf": "^6.0.1",
     "ts-inference-check": "^0.3.0",
     "ts-morph": "^28.0.0",
-    "@typescript/native": "npm:typescript@^7.0.2",
     "tsdown": "^0.22.7",
     "tsx": "^4.23.1",
     "typescript": "npm:@typescript/typescript6@^6.0.2",

--- a/src/lib/generated/classes/workflow.ts
+++ b/src/lib/generated/classes/workflow.ts
@@ -94,34 +94,54 @@ export class Workflow extends ObjectHydrator<Specification.Workflow> {
     return getLifecycleHooks('Workflow')?.normalize?.(copy) || copy;
   }
 
+  /**
+   * Deserializes the provided string as a Workflow
+   * @param text The YAML or JSON representation of a workflow
+   * @returns A new Workflow instance
+   */
   static deserialize(text: string): WorkflowIntersection {
     const model = yaml.load(text) as Partial<Specification.Workflow>;
     validate('Workflow', model);
     return new Workflow(model) as WorkflowIntersection;
   }
 
+  /**
+   * Serializes the provided workflow to YAML or JSON.
+   *
+   * Both formats serialize the same plain representation of the document, obtained via
+   * `asPlainObject()`: js-yaml cannot dump hydrated class instances. See issue #308.
+   *
+   * @param model The workflow to serialize
+   * @param format The format, 'yaml' or 'json', default is 'yaml'
+   * @param normalize If the workflow should be normalized before serialization, default true
+   * @returns A string representation of the workflow
+   */
   static serialize(
     model: Partial<WorkflowIntersection>,
     format: 'yaml' | 'json' = 'yaml',
     normalize: boolean = true,
-    validate: boolean = true,
   ): string {
     const workflow = new Workflow(model);
-    if (validate) {
-      workflow.validate();
-    }
-    const normalized = normalize ? workflow.normalize() : workflow;
-    const json = JSON.stringify(normalized);
-    if (format === 'json') {
-      return json;
-    }
-    return yaml.dump(JSON.parse(json));
+    workflow.validate();
+    const plainWorkflow = (normalize ? workflow.normalize() : workflow).asPlainObject();
+    return format === 'json' ? JSON.stringify(plainWorkflow) : yaml.dump(plainWorkflow);
   }
 
+  /**
+   * Creates a directed graph representation of the provided workflow
+   * @param model The workflow to convert
+   * @param options The options used to customize how the graph is built, e.g. to provide custom node ids
+   * @returns A directed graph of the provided workflow
+   */
   static toGraph(model: Partial<WorkflowIntersection>, options?: GraphBuildOptions): Graph {
     return buildGraph(model as unknown as WorkflowIntersection, options);
   }
 
+  /**
+   * Generates the MermaidJS code corresponding to the provided workflow
+   * @param model The workflow to convert
+   * @returns The MermaidJS code
+   */
   static toMermaidCode(model: Partial<WorkflowIntersection>): string {
     return convertToMermaidCode(model as unknown as WorkflowIntersection);
   }
@@ -130,11 +150,10 @@ export class Workflow extends ObjectHydrator<Specification.Workflow> {
    * Serializes the workflow to YAML or JSON
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
-   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true, validate: boolean = true): string {
-    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize, validate);
+  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true): string {
+    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize);
   }
 
   /**
@@ -168,15 +187,9 @@ export const _Workflow = Workflow as WorkflowConstructor & {
    * @param workflow The workflow to serialize
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
-   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(
-    workflow: Partial<WorkflowIntersection>,
-    format?: 'yaml' | 'json',
-    normalize?: boolean,
-    validate?: boolean,
-  ): string;
+  serialize(workflow: Partial<WorkflowIntersection>, format?: 'yaml' | 'json', normalize?: boolean): string;
 
   /**
    * Creates a directed graph representation of the provided workflow

--- a/src/lib/generated/classes/workflow.ts
+++ b/src/lib/generated/classes/workflow.ts
@@ -115,7 +115,6 @@ export class Workflow extends ObjectHydrator<Specification.Workflow> {
     if (format === 'json') {
       return json;
     }
-    // js-yaml only handles plain objects
     return yaml.dump(JSON.parse(json));
   }
 

--- a/src/lib/generated/classes/workflow.ts
+++ b/src/lib/generated/classes/workflow.ts
@@ -104,14 +104,19 @@ export class Workflow extends ObjectHydrator<Specification.Workflow> {
     model: Partial<WorkflowIntersection>,
     format: 'yaml' | 'json' = 'yaml',
     normalize: boolean = true,
+    validate: boolean = true,
   ): string {
     const workflow = new Workflow(model);
-    workflow.validate();
-    const normalized = normalize ? workflow.normalize() : workflow;
-    if (format === 'json') {
-      return JSON.stringify(normalized);
+    if (validate) {
+      workflow.validate();
     }
-    return yaml.dump(normalized);
+    const normalized = normalize ? workflow.normalize() : workflow;
+    const json = JSON.stringify(normalized);
+    if (format === 'json') {
+      return json;
+    }
+    // js-yaml only handles plain objects
+    return yaml.dump(JSON.parse(json));
   }
 
   static toGraph(model: Partial<WorkflowIntersection>, options?: GraphBuildOptions): Graph {
@@ -126,10 +131,11 @@ export class Workflow extends ObjectHydrator<Specification.Workflow> {
    * Serializes the workflow to YAML or JSON
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
+   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true): string {
-    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize);
+  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true, validate: boolean = true): string {
+    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize, validate);
   }
 
   /**
@@ -163,9 +169,15 @@ export const _Workflow = Workflow as WorkflowConstructor & {
    * @param workflow The workflow to serialize
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
+   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(workflow: Partial<WorkflowIntersection>, format?: 'yaml' | 'json', normalize?: boolean): string;
+  serialize(
+    workflow: Partial<WorkflowIntersection>,
+    format?: 'yaml' | 'json',
+    normalize?: boolean,
+    validate?: boolean,
+  ): string;
 
   /**
    * Creates a directed graph representation of the provided workflow

--- a/src/lib/hydrator.ts
+++ b/src/lib/hydrator.ts
@@ -21,10 +21,30 @@ import { deepCopy, isObject } from './utils';
  * A base class used for object hydration
  */
 export class ObjectHydrator<T> {
+  /**
+   * Instanciates a new instance of the ObjectHydrator class.
+   * Copies the own properties of the provided model onto the instance if it is an object.
+   *
+   * @param model - Optional partial model object to initialize the instance.
+   */
   constructor(model?: Partial<T>) {
     if (isObject(model)) {
       Object.assign(this, deepCopy(model));
     }
+  }
+
+  /**
+   * Converts the hydrated instance, and every hydrated instance nested within it, into plain data.
+   *
+   * Hydrated objects are class instances, which several plain data consumers reject: js-yaml v5
+   * identifies mappings with `Object.getPrototypeOf(data) === Object.prototype` and throws on
+   * anything else, and AJV reports class members as unevaluated properties. Use this method to
+   * obtain a representation safe to hand to such a consumer. See issue #308.
+   *
+   * @returns A plain object representation of the instance, free of class prototypes
+   */
+  asPlainObject(): T {
+    return deepCopy(this as unknown as T);
   }
 }
 
@@ -32,6 +52,12 @@ export class ObjectHydrator<T> {
  * A base class used for array hydration
  */
 export class ArrayHydrator<T> extends Array<T> {
+  /**
+   * Instanciates a new instance of the ArrayHydrator class.
+   * Copies the elements of the provided model onto the instance if it is an array.
+   *
+   * @param model - Optional array or number to initialize the instance.
+   */
   constructor(model?: Array<T> | number) {
     if (!isNaN(model as number)) {
       super(model as number);

--- a/tests/serialization/workflow-serialization.spec.ts
+++ b/tests/serialization/workflow-serialization.spec.ts
@@ -17,6 +17,7 @@
 
 import { Specification } from '../../src/lib/generated/definitions';
 import { Classes } from '../../src/lib/generated/classes';
+import { SchemaValidationError } from '../../src/lib/errors';
 
 import { schemaVersion } from '../../package.json';
 import { documentBuilder, setTaskBuilder, taskListBuilder, workflowBuilder } from '../../src';
@@ -107,5 +108,142 @@ describe('Workflow (de)serialization', () => {
     const expected = JSON.stringify(workflow);
     const serialized = Classes.Workflow.serialize(workflow, 'json');
     expect(serialized).toEqual(expected);
+  });
+});
+
+describe('Workflow serialization - YAML format', () => {
+  const data: Specification.Workflow = {
+    document: {
+      dsl: schemaVersion,
+      name: 'test',
+      version: '1.0.0',
+      namespace: 'default',
+    },
+    do: [
+      {
+        step1: {
+          set: {
+            foo: 'bar',
+          },
+        },
+      },
+    ],
+  };
+
+  it('should serialize as YAML by default from static method', () => {
+    const workflow = new Classes.Workflow(data);
+    const serialized = Classes.Workflow.serialize(workflow);
+    expect(typeof serialized).toBe('string');
+    expect(serialized).toMatch(/document:/);
+    expect(serialized).toMatch(/foo: bar/);
+  });
+
+  it('should serialize as YAML by default from instance method', () => {
+    const workflow = new Classes.Workflow(data);
+    const serialized = workflow.serialize();
+    expect(typeof serialized).toBe('string');
+    expect(serialized).toMatch(/document:/);
+    expect(serialized).toMatch(/foo: bar/);
+  });
+
+  it('should serialize as YAML when format is explicitly set to yaml', () => {
+    const workflow = new Classes.Workflow(data);
+    const serialized = Classes.Workflow.serialize(workflow, 'yaml');
+    expect(typeof serialized).toBe('string');
+    expect(serialized).toMatch(/document:/);
+  });
+});
+
+describe('Workflow serialization - normalize flag', () => {
+  const data: Specification.Workflow = {
+    document: {
+      dsl: schemaVersion,
+      name: 'test',
+      version: '1.0.0',
+      namespace: 'default',
+    },
+    do: [
+      {
+        step1: {
+          set: {
+            foo: 'bar',
+          },
+        },
+      },
+    ],
+  };
+
+  it('should serialize without normalizing when normalize is false (static method)', () => {
+    const workflow = new Classes.Workflow(data);
+    const serialized = Classes.Workflow.serialize(workflow, 'json', false);
+    const parsed = JSON.parse(serialized);
+    expect(parsed).toMatchObject(data);
+  });
+
+  it('should serialize without normalizing when normalize is false (instance method)', () => {
+    const workflow = new Classes.Workflow(data);
+    const serialized = workflow.serialize('json', false);
+    const parsed = JSON.parse(serialized);
+    expect(parsed).toMatchObject(data);
+  });
+});
+
+describe('Workflow serialization - validate flag', () => {
+  const validData: Specification.Workflow = {
+    document: {
+      dsl: schemaVersion,
+      name: 'test',
+      version: '1.0.0',
+      namespace: 'default',
+    },
+    do: [
+      {
+        step1: {
+          set: {
+            foo: 'bar',
+          },
+        },
+      },
+    ],
+  };
+
+  const invalidData = {
+    document: {
+      dsl: schemaVersion,
+      name: 'test',
+      version: '1.0.0',
+      namespace: 'default',
+    },
+    // missing required 'do'
+  } as unknown as Specification.Workflow;
+
+  it('should throw a SchemaValidationError when serializing an invalid workflow (static method)', () => {
+    const workflow = new Classes.Workflow(invalidData);
+    expect(() => Classes.Workflow.serialize(workflow, 'json')).toThrow(SchemaValidationError);
+  });
+
+  it('should throw a SchemaValidationError when serializing an invalid workflow (instance method)', () => {
+    const workflow = new Classes.Workflow(invalidData);
+    expect(() => workflow.serialize('json')).toThrow(SchemaValidationError);
+  });
+
+  it('should not throw when validate is false even for an invalid workflow (static method)', () => {
+    const workflow = new Classes.Workflow(invalidData);
+    expect(() => Classes.Workflow.serialize(workflow, 'json', true, false)).not.toThrow();
+  });
+
+  it('should not throw when validate is false even for an invalid workflow (instance method)', () => {
+    const workflow = new Classes.Workflow(invalidData);
+    expect(() => workflow.serialize('json', true, false)).not.toThrow();
+  });
+
+  it('should serialize a valid workflow without errors when validate is true (static method)', () => {
+    const workflow = new Classes.Workflow(validData);
+    expect(() => Classes.Workflow.serialize(workflow, 'json', true, true)).not.toThrow();
+  });
+
+  it('should serialize a valid workflow without errors when validate is true (instance method)', () => {
+    const workflow = new Classes.Workflow(validData);
+    expect(() => workflow.serialize('json', true, true)).not.toThrow();
   });
 });

--- a/tests/serialization/workflow-serialization.spec.ts
+++ b/tests/serialization/workflow-serialization.spec.ts
@@ -15,6 +15,8 @@
  *
  */
 
+import * as yaml from 'js-yaml';
+
 import { Specification } from '../../src/lib/generated/definitions';
 import { Classes } from '../../src/lib/generated/classes';
 import { SchemaValidationError } from '../../src/lib/errors';
@@ -22,228 +24,381 @@ import { SchemaValidationError } from '../../src/lib/errors';
 import { schemaVersion } from '../../package.json';
 import { documentBuilder, setTaskBuilder, taskListBuilder, workflowBuilder } from '../../src';
 
-describe('Workflow (de)serialization', () => {
-  it('should deserialize JSON', () => {
-    const data: Specification.Workflow = {
-      document: {
-        dsl: schemaVersion,
-        name: 'test',
-        version: '1.0.0',
-        namespace: 'default',
+/**
+ * The smallest valid workflow.
+ * Every scalar is kept under eighty characters: the exact output test asserts the serialized
+ * string byte for byte, and js-yaml folds longer scalars into block scalars.
+ */
+const minimalWorkflow: Specification.Workflow = {
+  document: {
+    dsl: schemaVersion,
+    name: 'test',
+    version: '1.0.0',
+    namespace: 'default',
+  },
+  do: [
+    {
+      step1: {
+        set: {
+          foo: 'bar',
+        },
       },
-      do: [
-        {
-          step1: {
-            set: {
-              foo: 'bar',
-            },
+    },
+  ],
+};
+
+/**
+ * A workflow exercising the constructs a YAML dumper is known to mis-encode: multi-task control
+ * flow, a summary long enough to force a folded block scalar, task names carrying YAML significant
+ * characters, version strings that must stay strings, numbers that must stay numbers, runtime and
+ * jq expressions, and empty objects and arrays.
+ */
+const complexWorkflow: Specification.Workflow = {
+  document: {
+    dsl: schemaVersion,
+    namespace: 'default',
+    name: 'kitchen-sink',
+    version: '1.0.0',
+    summary:
+      'A workflow whose summary is deliberately longer than the eighty character line width used by js-yaml, so that folded block scalars are exercised.',
+    tags: { owner: 'team-a', 'cost-center': '42' },
+  },
+  input: { schema: { format: 'json', document: { type: 'object' } } },
+  do: [
+    {
+      'consume/reading~1': {
+        listen: {
+          to: {
+            all: [
+              {
+                with: { source: 'https://my.home.com/sensor', type: 'my.home.sensors.temperature' },
+                correlate: { roomId: { from: '.roomid' } },
+              },
+              {
+                with: { source: 'https://my.home.com/sensor', type: 'my.home.sensors.humidity' },
+                correlate: { roomId: { from: '.roomid' } },
+              },
+            ],
           },
         },
-      ],
-    };
-    const dataJson = JSON.stringify(data);
-    const workflow = Classes.Workflow.deserialize(dataJson);
+        output: { as: '.data.reading' },
+      },
+    },
+    { 'say "hello world" (loudly)': { set: { greeting: '${ "hello " + .name }' } } },
+    {
+      scalars: {
+        set: {
+          version: '1.0',
+          enabled: 'no',
+          nothing: 'null',
+          one: '1',
+          zero: 0,
+          ratio: 1.5,
+          empty: {},
+          list: [],
+          expression: '${ .input.value + 1 }',
+          jq: '.data.reading',
+          at: '@here',
+          tilde: '~',
+          percent: '%50',
+          colon: 'key: value',
+          hash: 'a # b',
+        },
+      },
+    },
+    {
+      decide: {
+        switch: [{ matched: { when: '${ .value == 1 }', then: 'logReadings' } }, { default: { then: 'protect' } }],
+      },
+    },
+    {
+      logReadings: {
+        for: { each: 'reading', in: '.readings' },
+        do: [
+          {
+            callOrderService: {
+              call: 'openapi',
+              with: { document: { endpoint: 'http://myorg.io/ordersservices.json' }, operationId: 'logreading' },
+            },
+          },
+        ],
+      },
+    },
+    {
+      protect: {
+        try: [{ attempt: { set: { ok: true } } }],
+        catch: { as: 'err', do: [{ recover: { set: { recovered: true } } }] },
+      },
+    },
+    { branch: { fork: { compete: true, branches: [{ left: { set: { x: 1 } } }, { right: { set: { y: 2 } } }] } } },
+  ],
+  timeout: { after: { hours: 1, minutes: 30 } },
+  output: { as: '.result' },
+};
+
+/**
+ * A workflow missing the required 'do' property.
+ */
+const invalidWorkflow = {
+  document: {
+    dsl: schemaVersion,
+    name: 'test',
+    version: '1.0.0',
+    namespace: 'default',
+  },
+} as unknown as Specification.Workflow;
+
+/**
+ * Asserts the YAML and JSON serializations of the same workflow describe exactly the same
+ * document, with the same values in the same order, and that both match the expected plain
+ * document. YAML output diverging from JSON output is the failure mode of issue #308.
+ *
+ * The expected document leg assumes normalization is a no-op for Workflow, which holds as long
+ * as no normalize lifecycle hook is registered for it.
+ *
+ * @param yamlText The YAML serialization under test
+ * @param jsonText The JSON serialization of the same workflow
+ * @param expected The plain document both serializations are expected to describe
+ */
+const expectFormatsToAgree = (yamlText: string, jsonText: string, expected: Specification.Workflow): void => {
+  const fromYaml = yaml.load(yamlText);
+  expect(fromYaml).toStrictEqual(JSON.parse(jsonText));
+  expect(JSON.stringify(fromYaml)).toBe(jsonText);
+  expect(fromYaml).toStrictEqual(expected);
+};
+
+/**
+ * Builds the minimal workflow through the fluent API, yielding a graph in which the workflow, its
+ * document, its task list and its tasks are all hydrated class instances.
+ *
+ * @returns A fluently built equivalent of the minimal workflow
+ */
+const buildMinimalWorkflow = () =>
+  workflowBuilder()
+    .document(documentBuilder().dsl(schemaVersion).name('test').version('1.0.0').namespace('default').build())
+    .do(
+      taskListBuilder()
+        .push({
+          step1: setTaskBuilder().set({ foo: 'bar' }).build(),
+        })
+        .build(),
+    )
+    .build();
+
+describe('Workflow (de)serialization', () => {
+  it('should deserialize JSON', () => {
+    const workflow = Classes.Workflow.deserialize(JSON.stringify(minimalWorkflow));
     expect(workflow).toBeInstanceOf(Classes.Workflow);
+    expect(workflow.serialize('json')).toBe(JSON.stringify(minimalWorkflow));
+  });
+
+  it('should deserialize YAML', () => {
+    const workflow = Classes.Workflow.deserialize(`
+document:
+  dsl: '${schemaVersion}'
+  name: test
+  version: '1.0.0'
+  namespace: default
+do:
+  - step1:
+      set:
+        foo: bar`);
+    expect(workflow).toBeInstanceOf(Classes.Workflow);
+    expect(workflow.serialize('json')).toBe(JSON.stringify(minimalWorkflow));
   });
 
   it('should serialize as JSON from static method', () => {
-    const data: Specification.Workflow = {
-      document: {
-        dsl: schemaVersion,
-        name: 'test',
-        version: '1.0.0',
-        namespace: 'default',
-      },
-      do: [
-        {
-          step1: {
-            set: {
-              foo: 'bar',
-            },
-          },
-        },
-      ],
-    };
-    const workflow = new Classes.Workflow(data);
-    const expected = JSON.stringify(data);
-    const serialized = Classes.Workflow.serialize(workflow, 'json');
-    expect(serialized).toEqual(expected);
+    const workflow = new Classes.Workflow(minimalWorkflow);
+    expect(Classes.Workflow.serialize(workflow, 'json')).toEqual(JSON.stringify(minimalWorkflow));
   });
 
   it('should serialize as JSON from instance method', () => {
-    const data: Specification.Workflow = {
-      document: {
-        dsl: schemaVersion,
-        name: 'test',
-        version: '1.0.0',
-        namespace: 'default',
-      },
-      do: [
-        {
-          step1: {
-            set: {
-              foo: 'bar',
-            },
-          },
-        },
-      ],
-    };
-    const workflow = new Classes.Workflow(data);
-    const expected = JSON.stringify(data);
-    const serialized = workflow.serialize('json');
-    expect(serialized).toEqual(expected);
+    const workflow = new Classes.Workflow(minimalWorkflow);
+    expect(workflow.serialize('json')).toEqual(JSON.stringify(minimalWorkflow));
   });
 
-  it('should serialize as JSON from from static method from fluently built workflow', () => {
-    const workflow = workflowBuilder()
-      .document(documentBuilder().dsl('1.0.3').name('test').version('1.0.0').namespace('default').build())
-      .do(
-        taskListBuilder()
-          .push({
-            step1: setTaskBuilder().set({ foo: 'bar' }).build(),
-          })
-          .build(),
-      )
-      .build();
-    const expected = JSON.stringify(workflow);
-    const serialized = Classes.Workflow.serialize(workflow, 'json');
-    expect(serialized).toEqual(expected);
+  it('should serialize as JSON from static method from fluently built workflow', () => {
+    const workflow = buildMinimalWorkflow();
+    expect(Classes.Workflow.serialize(workflow, 'json')).toEqual(JSON.stringify(workflow));
   });
 });
 
 describe('Workflow serialization - YAML format', () => {
-  const data: Specification.Workflow = {
-    document: {
-      dsl: schemaVersion,
-      name: 'test',
-      version: '1.0.0',
-      namespace: 'default',
-    },
-    do: [
-      {
-        step1: {
-          set: {
-            foo: 'bar',
-          },
-        },
-      },
-    ],
-  };
-
-  it('should serialize as YAML by default from static method', () => {
-    const workflow = new Classes.Workflow(data);
-    const serialized = Classes.Workflow.serialize(workflow);
-    expect(typeof serialized).toBe('string');
-    expect(serialized).toMatch(/document:/);
-    expect(serialized).toMatch(/foo: bar/);
+  it('should serialize to YAML by default from the instance method', () => {
+    const workflow = new Classes.Workflow(minimalWorkflow);
+    expectFormatsToAgree(workflow.serialize(), workflow.serialize('json'), minimalWorkflow);
   });
 
-  it('should serialize as YAML by default from instance method', () => {
-    const workflow = new Classes.Workflow(data);
-    const serialized = workflow.serialize();
-    expect(typeof serialized).toBe('string');
-    expect(serialized).toMatch(/document:/);
-    expect(serialized).toMatch(/foo: bar/);
+  it('should serialize to YAML when the format is explicitly set to yaml', () => {
+    const workflow = new Classes.Workflow(minimalWorkflow);
+    expectFormatsToAgree(workflow.serialize('yaml'), workflow.serialize('json'), minimalWorkflow);
   });
 
-  it('should serialize as YAML when format is explicitly set to yaml', () => {
-    const workflow = new Classes.Workflow(data);
-    const serialized = Classes.Workflow.serialize(workflow, 'yaml');
-    expect(typeof serialized).toBe('string');
-    expect(serialized).toMatch(/document:/);
+  it('should serialize to YAML by default from the static method given a class instance', () => {
+    const workflow = new Classes.Workflow(minimalWorkflow);
+    expectFormatsToAgree(
+      Classes.Workflow.serialize(workflow),
+      Classes.Workflow.serialize(workflow, 'json'),
+      minimalWorkflow,
+    );
+  });
+
+  it('should serialize to YAML by default from the static method given a plain object', () => {
+    expectFormatsToAgree(
+      Classes.Workflow.serialize(minimalWorkflow),
+      Classes.Workflow.serialize(minimalWorkflow, 'json'),
+      minimalWorkflow,
+    );
+  });
+
+  it('should serialize a fluently built workflow to YAML', () => {
+    const workflow = buildMinimalWorkflow();
+    expectFormatsToAgree(workflow.serialize(), workflow.serialize('json'), minimalWorkflow);
+  });
+
+  it('should emit block-style YAML with the same key order as the JSON output', () => {
+    const workflow = new Classes.Workflow(minimalWorkflow);
+    expect(workflow.serialize()).toBe(
+      `document:
+  dsl: ${schemaVersion}
+  name: test
+  version: 1.0.0
+  namespace: default
+do:
+  - step1:
+      set:
+        foo: bar
+`,
+    );
+  });
+
+  it('should serialize a multi-task workflow with switch, try/catch, fork, nested for and timeout to YAML', () => {
+    const workflow = new Classes.Workflow(complexWorkflow);
+    expectFormatsToAgree(workflow.serialize(), workflow.serialize('json'), complexWorkflow);
+  });
+
+  it('should preserve the types of YAML-ambiguous scalars', () => {
+    const parsed = yaml.load(new Classes.Workflow(complexWorkflow).serialize()) as Record<string, any>;
+    expect(parsed.document.dsl).toBe(schemaVersion);
+    expect(parsed.document.version).toBe('1.0.0');
+    expect(parsed.document.summary).toBe(complexWorkflow.document.summary);
+    expect(parsed.document.tags['cost-center']).toBe('42');
+    expect(parsed.timeout.after.hours).toBe(1);
+    const { set } = parsed.do[2].scalars;
+    expect(set.version).toBe('1.0');
+    expect(set.enabled).toBe('no');
+    expect(set.nothing).toBe('null');
+    expect(set.one).toBe('1');
+    expect(set.zero).toBe(0);
+    expect(set.ratio).toBe(1.5);
+    expect(set.empty).toStrictEqual({});
+    expect(set.list).toStrictEqual([]);
+    expect(set.expression).toBe('${ .input.value + 1 }');
+    expect(set.jq).toBe('.data.reading');
+    expect(set.at).toBe('@here');
+    expect(set.tilde).toBe('~');
+    expect(set.percent).toBe('%50');
+    expect(set.colon).toBe('key: value');
+    expect(set.hash).toBe('a # b');
+    expect(parsed.do[3].decide.switch[0].matched.when).toBe('${ .value == 1 }');
+  });
+
+  it('should round-trip task names containing YAML-significant characters', () => {
+    const parsed = yaml.load(new Classes.Workflow(complexWorkflow).serialize()) as Record<string, any>;
+    expect(parsed.do.map((task: object) => Object.keys(task)[0])).toStrictEqual([
+      'consume/reading~1',
+      'say "hello world" (loudly)',
+      'scalars',
+      'decide',
+      'logReadings',
+      'protect',
+      'branch',
+    ]);
+  });
+
+  it('should not emit YAML tags in the serialized output', () => {
+    expect(new Classes.Workflow(complexWorkflow).serialize()).not.toMatch(/!!/);
+  });
+
+  it('should deserialize the YAML it produced back into an equivalent workflow', () => {
+    const workflow = new Classes.Workflow(complexWorkflow);
+    const roundTripped = Classes.Workflow.deserialize(workflow.serialize());
+    expect(roundTripped).toBeInstanceOf(Classes.Workflow);
+    expect(roundTripped.serialize('json')).toBe(workflow.serialize('json'));
   });
 });
 
 describe('Workflow serialization - normalize flag', () => {
-  const data: Specification.Workflow = {
-    document: {
-      dsl: schemaVersion,
-      name: 'test',
-      version: '1.0.0',
-      namespace: 'default',
-    },
-    do: [
-      {
-        step1: {
-          set: {
-            foo: 'bar',
-          },
-        },
-      },
-    ],
-  };
-
   it('should serialize without normalizing when normalize is false (static method)', () => {
-    const workflow = new Classes.Workflow(data);
-    const serialized = Classes.Workflow.serialize(workflow, 'json', false);
-    const parsed = JSON.parse(serialized);
-    expect(parsed).toMatchObject(data);
+    const workflow = new Classes.Workflow(minimalWorkflow);
+    expect(JSON.parse(Classes.Workflow.serialize(workflow, 'json', false))).toMatchObject(minimalWorkflow);
   });
 
   it('should serialize without normalizing when normalize is false (instance method)', () => {
-    const workflow = new Classes.Workflow(data);
-    const serialized = workflow.serialize('json', false);
-    const parsed = JSON.parse(serialized);
-    expect(parsed).toMatchObject(data);
+    const workflow = new Classes.Workflow(minimalWorkflow);
+    expect(JSON.parse(workflow.serialize('json', false))).toMatchObject(minimalWorkflow);
+  });
+
+  it('should serialize to YAML without normalizing when normalize is false (static method)', () => {
+    const workflow = new Classes.Workflow(complexWorkflow);
+    expectFormatsToAgree(
+      Classes.Workflow.serialize(workflow, 'yaml', false),
+      Classes.Workflow.serialize(workflow, 'json', false),
+      complexWorkflow,
+    );
+  });
+
+  it('should serialize to YAML without normalizing when normalize is false (instance method)', () => {
+    const workflow = new Classes.Workflow(complexWorkflow);
+    expectFormatsToAgree(workflow.serialize('yaml', false), workflow.serialize('json', false), complexWorkflow);
   });
 });
 
-describe('Workflow serialization - validate flag', () => {
-  const validData: Specification.Workflow = {
-    document: {
-      dsl: schemaVersion,
-      name: 'test',
-      version: '1.0.0',
-      namespace: 'default',
-    },
-    do: [
-      {
-        step1: {
-          set: {
-            foo: 'bar',
-          },
-        },
-      },
-    ],
-  };
-
-  const invalidData = {
-    document: {
-      dsl: schemaVersion,
-      name: 'test',
-      version: '1.0.0',
-      namespace: 'default',
-    },
-    // missing required 'do'
-  } as unknown as Specification.Workflow;
-
+describe('Workflow serialization - validation', () => {
   it('should throw a SchemaValidationError when serializing an invalid workflow (static method)', () => {
-    const workflow = new Classes.Workflow(invalidData);
-    expect(() => Classes.Workflow.serialize(workflow, 'json')).toThrow(SchemaValidationError);
+    const workflow = new Classes.Workflow(invalidWorkflow);
+    expect(() => Classes.Workflow.serialize(workflow)).toThrow(SchemaValidationError);
   });
 
   it('should throw a SchemaValidationError when serializing an invalid workflow (instance method)', () => {
-    const workflow = new Classes.Workflow(invalidData);
-    expect(() => workflow.serialize('json')).toThrow(SchemaValidationError);
+    const workflow = new Classes.Workflow(invalidWorkflow);
+    expect(() => workflow.serialize()).toThrow(SchemaValidationError);
+  });
+});
+
+describe('ObjectHydrator - plain object conversion', () => {
+  it('should convert a hydrated workflow into a plain object', () => {
+    const plainWorkflow = new Classes.Workflow(minimalWorkflow).asPlainObject();
+    expect(Object.getPrototypeOf(plainWorkflow)).toBe(Object.prototype);
+    expect(plainWorkflow).toStrictEqual(minimalWorkflow);
   });
 
-  it('should not throw when validate is false even for an invalid workflow (static method)', () => {
-    const workflow = new Classes.Workflow(invalidData);
-    expect(() => Classes.Workflow.serialize(workflow, 'json', true, false)).not.toThrow();
+  it('should convert nested hydrated instances into plain objects', () => {
+    const plainWorkflow = new Classes.Workflow(minimalWorkflow).asPlainObject();
+    expect(Object.getPrototypeOf(plainWorkflow.document)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(plainWorkflow.do)).toBe(Array.prototype);
+    expect(Object.getPrototypeOf(plainWorkflow.do[0])).toBe(Object.prototype);
   });
 
-  it('should not throw when validate is false even for an invalid workflow (instance method)', () => {
-    const workflow = new Classes.Workflow(invalidData);
-    expect(() => workflow.serialize('json', true, false)).not.toThrow();
+  it('should produce a plain object js-yaml can dump directly', () => {
+    expect(() => yaml.dump(new Classes.Workflow(minimalWorkflow).asPlainObject())).not.toThrow();
+  });
+});
+
+describe('Workflow serialization - js-yaml compatibility', () => {
+  it('should hydrate workflows as class instances rather than plain objects', () => {
+    const workflow = new Classes.Workflow(minimalWorkflow);
+    expect(Object.getPrototypeOf(workflow)).not.toBe(Object.prototype);
+    expect(workflow).toBeInstanceOf(Classes.Workflow);
   });
 
-  it('should serialize a valid workflow without errors when validate is true (static method)', () => {
-    const workflow = new Classes.Workflow(validData);
-    expect(() => Classes.Workflow.serialize(workflow, 'json', true, true)).not.toThrow();
-  });
-
-  it('should serialize a valid workflow without errors when validate is true (instance method)', () => {
-    const workflow = new Classes.Workflow(validData);
-    expect(() => workflow.serialize('json', true, true)).not.toThrow();
+  /**
+   * Canary. js-yaml v5 identifies mappings with Object.getPrototypeOf(data) === Object.prototype,
+   * so it refuses hydrated class instances; serialize converts to plain data first to work around
+   * it. If this test fails, js-yaml has relaxed that rule - re-evaluate the conversion rather than
+   * deleting this test.
+   */
+  it('should document that js-yaml cannot dump hydrated instances directly (issue #308)', () => {
+    expect(() => yaml.dump(new Classes.Workflow(minimalWorkflow))).toThrow(yaml.YAMLException);
   });
 });

--- a/tools/4_generate-classes.ts
+++ b/tools/4_generate-classes.ts
@@ -112,34 +112,54 @@ export class ${name} extends ${baseClass ? '_' + baseClass : `ObjectHydrator<Spe
   ${
     name === 'Workflow'
       ? `
+  /**
+   * Deserializes the provided string as a Workflow
+   * @param text The YAML or JSON representation of a workflow
+   * @returns A new Workflow instance
+   */
   static deserialize(text: string): WorkflowIntersection {
     const model = yaml.load(text) as Partial<Specification.Workflow>;
     validate('Workflow', model);
     return new Workflow(model) as WorkflowIntersection;
   }
 
+  /**
+   * Serializes the provided workflow to YAML or JSON.
+   *
+   * Both formats serialize the same plain representation of the document, obtained via
+   * \`asPlainObject()\`: js-yaml cannot dump hydrated class instances. See issue #308.
+   *
+   * @param model The workflow to serialize
+   * @param format The format, 'yaml' or 'json', default is 'yaml'
+   * @param normalize If the workflow should be normalized before serialization, default true
+   * @returns A string representation of the workflow
+   */
   static serialize(
     model: Partial<WorkflowIntersection>,
     format: 'yaml' | 'json' = 'yaml',
     normalize: boolean = true,
-    validate: boolean = true,
   ): string {
     const workflow = new Workflow(model);
-    if (validate) {
-      workflow.validate();
-    }
-    const normalized = normalize ? workflow.normalize() : workflow;
-    const json = JSON.stringify(normalized);
-    if (format === 'json') {
-      return json;
-    }
-    return yaml.dump(JSON.parse(json));
+    workflow.validate();
+    const plainWorkflow = (normalize ? workflow.normalize() : workflow).asPlainObject();
+    return format === 'json' ? JSON.stringify(plainWorkflow) : yaml.dump(plainWorkflow);
   }
 
+  /**
+   * Creates a directed graph representation of the provided workflow
+   * @param model The workflow to convert
+   * @param options The options used to customize how the graph is built, e.g. to provide custom node ids
+   * @returns A directed graph of the provided workflow
+   */
   static toGraph(model: Partial<WorkflowIntersection>, options?: GraphBuildOptions): Graph {
     return buildGraph(model as unknown as WorkflowIntersection, options);
   }
 
+  /**
+   * Generates the MermaidJS code corresponding to the provided workflow
+   * @param model The workflow to convert
+   * @returns The MermaidJS code
+   */
   static toMermaidCode(model: Partial<WorkflowIntersection>): string {
     return convertToMermaidCode(model as unknown as WorkflowIntersection);
   }
@@ -148,11 +168,10 @@ export class ${name} extends ${baseClass ? '_' + baseClass : `ObjectHydrator<Spe
    * Serializes the workflow to YAML or JSON
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
-   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true, validate: boolean = true): string {
-    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize, validate);
+  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true): string {
+    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize);
   }
 
   /**
@@ -190,10 +209,9 @@ export const _${name} = ${name} as ${name}Constructor${
    * @param workflow The workflow to serialize
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
-   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(workflow: Partial<WorkflowIntersection>, format?: 'yaml' | 'json', normalize?: boolean, validate?: boolean): string;
+  serialize(workflow: Partial<WorkflowIntersection>, format?: 'yaml' | 'json', normalize?: boolean): string;
 
   /**
    * Creates a directed graph representation of the provided workflow

--- a/tools/4_generate-classes.ts
+++ b/tools/4_generate-classes.ts
@@ -122,14 +122,18 @@ export class ${name} extends ${baseClass ? '_' + baseClass : `ObjectHydrator<Spe
     model: Partial<WorkflowIntersection>,
     format: 'yaml' | 'json' = 'yaml',
     normalize: boolean = true,
+    validate: boolean = true,
   ): string {
     const workflow = new Workflow(model);
-    workflow.validate();
-    const normalized = normalize ? workflow.normalize() : workflow;
-    if (format === 'json') {
-      return JSON.stringify(normalized);
+    if (validate) {
+      workflow.validate();
     }
-    return yaml.dump(normalized);
+    const normalized = normalize ? workflow.normalize() : workflow;
+    const json = JSON.stringify(normalized);
+    if (format === 'json') {
+      return json;
+    }
+    return yaml.dump(JSON.parse(json));
   }
 
   static toGraph(model: Partial<WorkflowIntersection>, options?: GraphBuildOptions): Graph {
@@ -144,10 +148,11 @@ export class ${name} extends ${baseClass ? '_' + baseClass : `ObjectHydrator<Spe
    * Serializes the workflow to YAML or JSON
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
+   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true): string {
-    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize);
+  serialize(format: 'yaml' | 'json' = 'yaml', normalize: boolean = true, validate: boolean = true): string {
+    return Workflow.serialize(this as unknown as WorkflowIntersection, format, normalize, validate);
   }
 
   /**
@@ -185,9 +190,10 @@ export const _${name} = ${name} as ${name}Constructor${
    * @param workflow The workflow to serialize
    * @param format The format, 'yaml' or 'json', default is 'yaml'
    * @param normalize If the workflow should be normalized before serialization, default true
+   * @param validate If the workflow should be validated before serialization, default true
    * @returns A string representation of the workflow
    */
-  serialize(workflow: Partial<WorkflowIntersection>, format?: 'yaml' | 'json', normalize?: boolean): string;
+  serialize(workflow: Partial<WorkflowIntersection>, format?: 'yaml' | 'json', normalize?: boolean, validate?: boolean): string;
 
   /**
    * Creates a directed graph representation of the provided workflow


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

Fixes #308.

`Workflow.serialize()` threw `YAMLException: unacceptable kind of an object to dump [object Object]` for every YAML call, whether through the instance method or static method, and whether given a class instance or plain object. YAML is the default format, so every snippet under `examples/` was on the broken path, and no published version from `1.0.3-alpha4` through `alpha7` could emit YAML at all.

The cause is a runtime regression introduced by the js-yaml 4 → 5 major bump in `2503e87` (#275). js-yaml v4 identified mappings using `Object.prototype.toString.call(o) === '[object Object]'`, which accepts class instances. v5 rewrote the dumper, and `mapTag.identify` now uses `isPlainObject`, which requires `Object.getPrototypeOf(data) === Object.prototype`. Hydrated `ObjectHydrator` descendants fail that check, no tag matches, and `dump()` throws.

`TaskList` and the other `ArrayHydrator` subclasses are unaffected because they are genuine `Array` exotic objects, so `Array.isArray()` still identifies them correctly.

This PR adds `ObjectHydrator.asPlainObject()` and serializes both formats from the plain representation it returns:

```ts
const plainWorkflow = (normalize ? workflow.normalize() : workflow).asPlainObject();

return format === 'json' ? JSON.stringify(plainWorkflow) : yaml.dump(plainWorkflow);
```

Putting the conversion on the hydrator rather than inline at the call site gives us three things that a local `deepCopy(...)` would not:

* **It closes the same hazard for consumers.** Every builder returns class instances, so `yaml.dump(taskListBuilder().build())` was exposed to the same class of problem. Consumers now have a supported way to get plain spec data instead of only fixing our own `serialize()` path.

* **It is type-honest.** `Workflow extends ObjectHydrator<Specification.Workflow>`, so `workflow.asPlainObject()` is typed as `Specification.Workflow`, which is what it actually returns: plain spec data. `deepCopy` has the signature `<T>(obj: T): T`, so calling it on a `Workflow` claims the result is still a `Workflow` even though the prototypes are gone.

* **It is harder to accidentally undo.** A named, documented method makes the boundary explicit. An inline `yaml.dump(JSON.parse(JSON.stringify(x)))` or equivalent is much easier for a future cleanup to simplify away without realizing why it exists.

CI stayed green through the original dependency bump because the test suite had zero YAML coverage. All four `serialize()` calls in the serialization spec explicitly passed `'json'`.

The serialization spec is now built around one invariant: **the YAML output, the JSON output, and the source document are the same document**, with assertions covering values, key order, and prototypes.

**Special notes for reviewers**:

* **Not all 27 tests are regression coverage.** 13 fail without the fix, all with the exact error from the issue. The `js-yaml compatibility` block contains 2 tests that pass either way. Those are deliberate canaries documenting why the conversion exists, so a future js-yaml behavior change shows up as a named failure instead of silently removing the reason for the workaround. Please do not count those two as proof of the regression fix itself.

* **`serialize()` loses a parameter, but not a released one.** The `validate` flag came from the cherry-picked commits below and was never part of a published version. `1.0.3-alpha7` ships the same three parameters this PR ends with, so this is **not** a breaking change. The flag is dropped because #309 proposes a `SerializationOptions` / `DeserializationOptions` payload, and shipping a fourth positional boolean only to deprecate it in the same release does not buy us anything. #309 remains fully open.

* **`asPlainObject()` is deliberately not added to `ArrayHydrator`.** Its subclasses are real `Array` exotic objects that js-yaml already handles correctly, so there is no equivalent hazard to close there, and `asPlainObject()` would also be the wrong name for an array. The asymmetry is intentional.

* **`src/lib/generated/classes/workflow.ts` was regenerated, not hand-edited.** Only `tools/4_generate-classes.ts` was edited. The generated class was then reproduced from it, so codegen parity holds by construction.

* **`@typescript/native` moved in `package.json`.** `npm uninstall @types/js-yaml` re-sorted `devDependencies` alphabetically. The entry had been sitting out of order after `ts-morph`. This is unrelated to the fix, and reverting it would just be undone by the next `npm install`.

**Additional information (if needed):**

**Credit.** The first two commits are @handreyrc's, cherry-picked from their branch on #307, where the issue was originally reported and first fixed. #306 mixed the bug and API request together, so it was split into #308 for the regression and #309 for the options payload. #306 and #307 were then closed, but the original commits and authorship are preserved here.

**Please merge with a merge commit or rebase, not a squash**, so that authorship stays intact.

**Verification.**

* `npm test`: 137 passed across 19 files. `npm run lint`, `npm run build`, and `npm run validate:package` are all clean.

* I verified the regression by temporarily restoring the broken dump path in the generated class. Exactly 13 tests fail with `YAMLException: unacceptable kind of an object to dump [object Object]`. Running codegen then restores the fixed file deterministically.

* Codegen parity was checked offline. `tools:4_generate-classes` + `format` leaves only `workflow.ts` changed, and the result is byte-stable across repeated runs. The full `codegen:check` reaches `open-workflow-specification.org`, so this avoids depending on network access for the parity check.

* End to end against the built package: `npm run build && npx tsx examples/node/using-fluent-api.ts` now prints block YAML instead of throwing.

**`@types/js-yaml` removed.** js-yaml 5 ships its own typings, and `--traceResolution` confirms that every `import 'js-yaml'` in both the tools and tests projects resolves to `js-yaml/dist/js-yaml.d.ts@5.3.0`. The pinned v4 `@types` package was never consulted.

For the record, this is **not** why the bug slipped past TypeScript. `dump(input: any, options?: DumpOptions)` accepts `any`, so the runtime prototype check is invisible to the type system regardless of which typings are installed.

**Release.** Bumped to `1.0.3-alpha8`, since every published version from `1.0.3-alpha4` onward is affected and there is currently no usable release that can emit YAML. The release notes should call out the js-yaml 4 → 5 major bump as the cause.

**Worth a follow-up, out of scope here.** This shipped because a Dependabot **major** bump of a **runtime** dependency merged on green CI. Separating runtime majors from the auto-merge group would give the next one a better chance of getting deliberate review.

Separately, `if (typeof model.output === 'object')` is also true for `null`, so `output: null` hydrates to `{}` in `workflow.ts` and roughly forty sibling classes. That is unrelated to this fix, but worth tracking independently.
