### PR TITLE
chore: fix instanciate -> instantiate typo

### DIFF
--- a/src/lib/generated/classes/a2a-arguments.ts
+++ b/src/lib/generated/classes/a2a-arguments.ts
@@ -46,7 +46,7 @@ export interface A2AArgumentsConstructor {
  */
 export class A2AArguments extends ObjectHydrator<Specification.A2AArguments> {
   /**
-   * Instanciates a new instance of the A2AArguments class.
+   * Instantiates a new instance of the A2AArguments class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the A2AArguments.

--- a/src/lib/generated/classes/all-event-consumption-strategy.ts
+++ b/src/lib/generated/classes/all-event-consumption-strategy.ts
@@ -46,7 +46,7 @@ export interface AllEventConsumptionStrategyConstructor {
  */
 export class AllEventConsumptionStrategy extends ObjectHydrator<Specification.AllEventConsumptionStrategy> {
   /**
-   * Instanciates a new instance of the AllEventConsumptionStrategy class.
+   * Instantiates a new instance of the AllEventConsumptionStrategy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the AllEventConsumptionStrategy.

--- a/src/lib/generated/classes/any-event-consumption-strategy-until.ts
+++ b/src/lib/generated/classes/any-event-consumption-strategy-until.ts
@@ -48,7 +48,7 @@ export interface AnyEventConsumptionStrategyUntilConstructor {
  */
 export class AnyEventConsumptionStrategyUntil extends ObjectHydrator<Specification.AnyEventConsumptionStrategyUntil> {
   /**
-   * Instanciates a new instance of the AnyEventConsumptionStrategyUntil class.
+   * Instantiates a new instance of the AnyEventConsumptionStrategyUntil class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the AnyEventConsumptionStrategyUntil.

--- a/src/lib/generated/classes/any-event-consumption-strategy.ts
+++ b/src/lib/generated/classes/any-event-consumption-strategy.ts
@@ -47,7 +47,7 @@ export interface AnyEventConsumptionStrategyConstructor {
  */
 export class AnyEventConsumptionStrategy extends ObjectHydrator<Specification.AnyEventConsumptionStrategy> {
   /**
-   * Instanciates a new instance of the AnyEventConsumptionStrategy class.
+   * Instantiates a new instance of the AnyEventConsumptionStrategy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the AnyEventConsumptionStrategy.

--- a/src/lib/generated/classes/any-event-until-consumed.ts
+++ b/src/lib/generated/classes/any-event-until-consumed.ts
@@ -47,7 +47,7 @@ export interface AnyEventUntilConsumedConstructor {
  */
 export class AnyEventUntilConsumed extends ObjectHydrator<Specification.AnyEventUntilConsumed> {
   /**
-   * Instanciates a new instance of the AnyEventUntilConsumed class.
+   * Instantiates a new instance of the AnyEventUntilConsumed class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the AnyEventUntilConsumed.

--- a/src/lib/generated/classes/async-api-arguments.ts
+++ b/src/lib/generated/classes/async-api-arguments.ts
@@ -43,7 +43,7 @@ export interface AsyncApiArgumentsConstructor {
  */
 export class AsyncApiArguments extends ObjectHydrator<Specification.AsyncApiArguments> {
   /**
-   * Instanciates a new instance of the AsyncApiArguments class.
+   * Instantiates a new instance of the AsyncApiArguments class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the AsyncApiArguments.

--- a/src/lib/generated/classes/authentication-policy-reference.ts
+++ b/src/lib/generated/classes/authentication-policy-reference.ts
@@ -44,7 +44,7 @@ export interface AuthenticationPolicyReferenceConstructor {
  */
 export class AuthenticationPolicyReference extends ObjectHydrator<Specification.AuthenticationPolicyReference> {
   /**
-   * Instanciates a new instance of the AuthenticationPolicyReference class.
+   * Instantiates a new instance of the AuthenticationPolicyReference class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the AuthenticationPolicyReference.

--- a/src/lib/generated/classes/authentication-policy.ts
+++ b/src/lib/generated/classes/authentication-policy.ts
@@ -49,7 +49,7 @@ export interface AuthenticationPolicyConstructor {
  */
 export class AuthenticationPolicy extends ObjectHydrator<Specification.AuthenticationPolicy> {
   /**
-   * Instanciates a new instance of the AuthenticationPolicy class.
+   * Instantiates a new instance of the AuthenticationPolicy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the AuthenticationPolicy.

--- a/src/lib/generated/classes/basic-authentication-policy-configuration.ts
+++ b/src/lib/generated/classes/basic-authentication-policy-configuration.ts
@@ -46,7 +46,7 @@ export interface BasicAuthenticationPolicyConfigurationConstructor {
  */
 export class BasicAuthenticationPolicyConfiguration extends ObjectHydrator<Specification.BasicAuthenticationPolicyConfiguration> {
   /**
-   * Instanciates a new instance of the BasicAuthenticationPolicyConfiguration class.
+   * Instantiates a new instance of the BasicAuthenticationPolicyConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the BasicAuthenticationPolicyConfiguration.

--- a/src/lib/generated/classes/basic-authentication-policy.ts
+++ b/src/lib/generated/classes/basic-authentication-policy.ts
@@ -45,7 +45,7 @@ export interface BasicAuthenticationPolicyConstructor {
  */
 export class BasicAuthenticationPolicy extends ObjectHydrator<Specification.BasicAuthenticationPolicy> {
   /**
-   * Instanciates a new instance of the BasicAuthenticationPolicy class.
+   * Instantiates a new instance of the BasicAuthenticationPolicy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the BasicAuthenticationPolicy.

--- a/src/lib/generated/classes/basic-authentication-properties.ts
+++ b/src/lib/generated/classes/basic-authentication-properties.ts
@@ -44,7 +44,7 @@ export interface BasicAuthenticationPropertiesConstructor {
  */
 export class BasicAuthenticationProperties extends ObjectHydrator<Specification.BasicAuthenticationProperties> {
   /**
-   * Instanciates a new instance of the BasicAuthenticationProperties class.
+   * Instantiates a new instance of the BasicAuthenticationProperties class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the BasicAuthenticationProperties.

--- a/src/lib/generated/classes/bearer-authentication-policy-configuration.ts
+++ b/src/lib/generated/classes/bearer-authentication-policy-configuration.ts
@@ -46,7 +46,7 @@ export interface BearerAuthenticationPolicyConfigurationConstructor {
  */
 export class BearerAuthenticationPolicyConfiguration extends ObjectHydrator<Specification.BearerAuthenticationPolicyConfiguration> {
   /**
-   * Instanciates a new instance of the BearerAuthenticationPolicyConfiguration class.
+   * Instantiates a new instance of the BearerAuthenticationPolicyConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the BearerAuthenticationPolicyConfiguration.

--- a/src/lib/generated/classes/bearer-authentication-policy.ts
+++ b/src/lib/generated/classes/bearer-authentication-policy.ts
@@ -46,7 +46,7 @@ export interface BearerAuthenticationPolicyConstructor {
  */
 export class BearerAuthenticationPolicy extends ObjectHydrator<Specification.BearerAuthenticationPolicy> {
   /**
-   * Instanciates a new instance of the BearerAuthenticationPolicy class.
+   * Instantiates a new instance of the BearerAuthenticationPolicy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the BearerAuthenticationPolicy.

--- a/src/lib/generated/classes/bearer-authentication-properties.ts
+++ b/src/lib/generated/classes/bearer-authentication-properties.ts
@@ -44,7 +44,7 @@ export interface BearerAuthenticationPropertiesConstructor {
  */
 export class BearerAuthenticationProperties extends ObjectHydrator<Specification.BearerAuthenticationProperties> {
   /**
-   * Instanciates a new instance of the BearerAuthenticationProperties class.
+   * Instantiates a new instance of the BearerAuthenticationProperties class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the BearerAuthenticationProperties.

--- a/src/lib/generated/classes/call-a2a.ts
+++ b/src/lib/generated/classes/call-a2a.ts
@@ -50,7 +50,7 @@ export interface CallA2AConstructor {
  */
 export class CallA2A extends _TaskBase {
   /**
-   * Instanciates a new instance of the CallA2A class.
+   * Instantiates a new instance of the CallA2A class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the CallA2A.

--- a/src/lib/generated/classes/call-async-api.ts
+++ b/src/lib/generated/classes/call-async-api.ts
@@ -49,7 +49,7 @@ export interface CallAsyncAPIConstructor {
  */
 export class CallAsyncAPI extends _TaskBase {
   /**
-   * Instanciates a new instance of the CallAsyncAPI class.
+   * Instantiates a new instance of the CallAsyncAPI class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the CallAsyncAPI.

--- a/src/lib/generated/classes/call-function.ts
+++ b/src/lib/generated/classes/call-function.ts
@@ -50,7 +50,7 @@ export interface CallFunctionConstructor {
  */
 export class CallFunction extends _TaskBase {
   /**
-   * Instanciates a new instance of the CallFunction class.
+   * Instantiates a new instance of the CallFunction class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the CallFunction.

--- a/src/lib/generated/classes/call-grpc.ts
+++ b/src/lib/generated/classes/call-grpc.ts
@@ -50,7 +50,7 @@ export interface CallGRPCConstructor {
  */
 export class CallGRPC extends _TaskBase {
   /**
-   * Instanciates a new instance of the CallGRPC class.
+   * Instantiates a new instance of the CallGRPC class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the CallGRPC.

--- a/src/lib/generated/classes/call-http.ts
+++ b/src/lib/generated/classes/call-http.ts
@@ -50,7 +50,7 @@ export interface CallHTTPConstructor {
  */
 export class CallHTTP extends _TaskBase {
   /**
-   * Instanciates a new instance of the CallHTTP class.
+   * Instantiates a new instance of the CallHTTP class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the CallHTTP.

--- a/src/lib/generated/classes/call-mcp.ts
+++ b/src/lib/generated/classes/call-mcp.ts
@@ -50,7 +50,7 @@ export interface CallMCPConstructor {
  */
 export class CallMCP extends _TaskBase {
   /**
-   * Instanciates a new instance of the CallMCP class.
+   * Instantiates a new instance of the CallMCP class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the CallMCP.

--- a/src/lib/generated/classes/call-open-api.ts
+++ b/src/lib/generated/classes/call-open-api.ts
@@ -50,7 +50,7 @@ export interface CallOpenAPIConstructor {
  */
 export class CallOpenAPI extends _TaskBase {
   /**
-   * Instanciates a new instance of the CallOpenAPI class.
+   * Instantiates a new instance of the CallOpenAPI class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the CallOpenAPI.

--- a/src/lib/generated/classes/call-task.ts
+++ b/src/lib/generated/classes/call-task.ts
@@ -49,7 +49,7 @@ export interface CallTaskConstructor {
  */
 export class CallTask extends ObjectHydrator<Specification.CallTask> {
   /**
-   * Instanciates a new instance of the CallTask class.
+   * Instantiates a new instance of the CallTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the CallTask.

--- a/src/lib/generated/classes/catalog.ts
+++ b/src/lib/generated/classes/catalog.ts
@@ -45,7 +45,7 @@ export interface CatalogConstructor {
  */
 export class Catalog extends ObjectHydrator<Specification.Catalog> {
   /**
-   * Instanciates a new instance of the Catalog class.
+   * Instantiates a new instance of the Catalog class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Catalog.

--- a/src/lib/generated/classes/catch-errors.ts
+++ b/src/lib/generated/classes/catch-errors.ts
@@ -45,7 +45,7 @@ export interface CatchErrorsConstructor {
  */
 export class CatchErrors extends ObjectHydrator<Specification.CatchErrors> {
   /**
-   * Instanciates a new instance of the CatchErrors class.
+   * Instantiates a new instance of the CatchErrors class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the CatchErrors.

--- a/src/lib/generated/classes/constant-backoff.ts
+++ b/src/lib/generated/classes/constant-backoff.ts
@@ -43,7 +43,7 @@ export interface ConstantBackoffConstructor {
  */
 export class ConstantBackoff extends ObjectHydrator<Specification.ConstantBackoff> {
   /**
-   * Instanciates a new instance of the ConstantBackoff class.
+   * Instantiates a new instance of the ConstantBackoff class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ConstantBackoff.

--- a/src/lib/generated/classes/container-environment.ts
+++ b/src/lib/generated/classes/container-environment.ts
@@ -43,7 +43,7 @@ export interface ContainerEnvironmentConstructor {
  */
 export class ContainerEnvironment extends ObjectHydrator<Specification.ContainerEnvironment> {
   /**
-   * Instanciates a new instance of the ContainerEnvironment class.
+   * Instantiates a new instance of the ContainerEnvironment class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ContainerEnvironment.

--- a/src/lib/generated/classes/container-lifetime.ts
+++ b/src/lib/generated/classes/container-lifetime.ts
@@ -45,7 +45,7 @@ export interface ContainerLifetimeConstructor {
  */
 export class ContainerLifetime extends ObjectHydrator<Specification.ContainerLifetime> {
   /**
-   * Instanciates a new instance of the ContainerLifetime class.
+   * Instantiates a new instance of the ContainerLifetime class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ContainerLifetime.

--- a/src/lib/generated/classes/container-ports.ts
+++ b/src/lib/generated/classes/container-ports.ts
@@ -43,7 +43,7 @@ export interface ContainerPortsConstructor {
  */
 export class ContainerPorts extends ObjectHydrator<Specification.ContainerPorts> {
   /**
-   * Instanciates a new instance of the ContainerPorts class.
+   * Instantiates a new instance of the ContainerPorts class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ContainerPorts.

--- a/src/lib/generated/classes/container-volumes.ts
+++ b/src/lib/generated/classes/container-volumes.ts
@@ -43,7 +43,7 @@ export interface ContainerVolumesConstructor {
  */
 export class ContainerVolumes extends ObjectHydrator<Specification.ContainerVolumes> {
   /**
-   * Instanciates a new instance of the ContainerVolumes class.
+   * Instantiates a new instance of the ContainerVolumes class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ContainerVolumes.

--- a/src/lib/generated/classes/container.ts
+++ b/src/lib/generated/classes/container.ts
@@ -48,7 +48,7 @@ export interface ContainerConstructor {
  */
 export class Container extends ObjectHydrator<Specification.Container> {
   /**
-   * Instanciates a new instance of the Container class.
+   * Instantiates a new instance of the Container class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Container.

--- a/src/lib/generated/classes/digest-authentication-policy-configuration.ts
+++ b/src/lib/generated/classes/digest-authentication-policy-configuration.ts
@@ -46,7 +46,7 @@ export interface DigestAuthenticationPolicyConfigurationConstructor {
  */
 export class DigestAuthenticationPolicyConfiguration extends ObjectHydrator<Specification.DigestAuthenticationPolicyConfiguration> {
   /**
-   * Instanciates a new instance of the DigestAuthenticationPolicyConfiguration class.
+   * Instantiates a new instance of the DigestAuthenticationPolicyConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the DigestAuthenticationPolicyConfiguration.

--- a/src/lib/generated/classes/digest-authentication-policy.ts
+++ b/src/lib/generated/classes/digest-authentication-policy.ts
@@ -46,7 +46,7 @@ export interface DigestAuthenticationPolicyConstructor {
  */
 export class DigestAuthenticationPolicy extends ObjectHydrator<Specification.DigestAuthenticationPolicy> {
   /**
-   * Instanciates a new instance of the DigestAuthenticationPolicy class.
+   * Instantiates a new instance of the DigestAuthenticationPolicy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the DigestAuthenticationPolicy.

--- a/src/lib/generated/classes/digest-authentication-properties.ts
+++ b/src/lib/generated/classes/digest-authentication-properties.ts
@@ -44,7 +44,7 @@ export interface DigestAuthenticationPropertiesConstructor {
  */
 export class DigestAuthenticationProperties extends ObjectHydrator<Specification.DigestAuthenticationProperties> {
   /**
-   * Instanciates a new instance of the DigestAuthenticationProperties class.
+   * Instantiates a new instance of the DigestAuthenticationProperties class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the DigestAuthenticationProperties.

--- a/src/lib/generated/classes/do-task.ts
+++ b/src/lib/generated/classes/do-task.ts
@@ -50,7 +50,7 @@ export interface DoTaskConstructor {
  */
 export class DoTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the DoTask class.
+   * Instantiates a new instance of the DoTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the DoTask.

--- a/src/lib/generated/classes/document.ts
+++ b/src/lib/generated/classes/document.ts
@@ -46,7 +46,7 @@ export interface DocumentConstructor {
  */
 export class Document extends ObjectHydrator<Specification.Document> {
   /**
-   * Instanciates a new instance of the Document class.
+   * Instantiates a new instance of the Document class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Document.

--- a/src/lib/generated/classes/duration-inline.ts
+++ b/src/lib/generated/classes/duration-inline.ts
@@ -43,7 +43,7 @@ export interface DurationInlineConstructor {
  */
 export class DurationInline extends ObjectHydrator<Specification.DurationInline> {
   /**
-   * Instanciates a new instance of the DurationInline class.
+   * Instantiates a new instance of the DurationInline class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the DurationInline.

--- a/src/lib/generated/classes/duration.ts
+++ b/src/lib/generated/classes/duration.ts
@@ -43,7 +43,7 @@ export interface DurationConstructor {
  */
 export class Duration extends ObjectHydrator<Specification.Duration> {
   /**
-   * Instanciates a new instance of the Duration class.
+   * Instantiates a new instance of the Duration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Duration.

--- a/src/lib/generated/classes/emit-event-definition.ts
+++ b/src/lib/generated/classes/emit-event-definition.ts
@@ -45,7 +45,7 @@ export interface EmitEventDefinitionConstructor {
  */
 export class EmitEventDefinition extends ObjectHydrator<Specification.EmitEventDefinition> {
   /**
-   * Instanciates a new instance of the EmitEventDefinition class.
+   * Instantiates a new instance of the EmitEventDefinition class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EmitEventDefinition.

--- a/src/lib/generated/classes/emit-event-with.ts
+++ b/src/lib/generated/classes/emit-event-with.ts
@@ -43,7 +43,7 @@ export interface EmitEventWithConstructor {
  */
 export class EmitEventWith extends ObjectHydrator<Specification.EmitEventWith> {
   /**
-   * Instanciates a new instance of the EmitEventWith class.
+   * Instantiates a new instance of the EmitEventWith class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EmitEventWith.

--- a/src/lib/generated/classes/emit-task-configuration.ts
+++ b/src/lib/generated/classes/emit-task-configuration.ts
@@ -45,7 +45,7 @@ export interface EmitTaskConfigurationConstructor {
  */
 export class EmitTaskConfiguration extends ObjectHydrator<Specification.EmitTaskConfiguration> {
   /**
-   * Instanciates a new instance of the EmitTaskConfiguration class.
+   * Instantiates a new instance of the EmitTaskConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EmitTaskConfiguration.

--- a/src/lib/generated/classes/emit-task.ts
+++ b/src/lib/generated/classes/emit-task.ts
@@ -50,7 +50,7 @@ export interface EmitTaskConstructor {
  */
 export class EmitTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the EmitTask class.
+   * Instantiates a new instance of the EmitTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EmitTask.

--- a/src/lib/generated/classes/endpoint-configuration.ts
+++ b/src/lib/generated/classes/endpoint-configuration.ts
@@ -45,7 +45,7 @@ export interface EndpointConfigurationConstructor {
  */
 export class EndpointConfiguration extends ObjectHydrator<Specification.EndpointConfiguration> {
   /**
-   * Instanciates a new instance of the EndpointConfiguration class.
+   * Instantiates a new instance of the EndpointConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EndpointConfiguration.

--- a/src/lib/generated/classes/endpoint-uri.ts
+++ b/src/lib/generated/classes/endpoint-uri.ts
@@ -43,7 +43,7 @@ export interface EndpointUriConstructor {
  */
 export class EndpointUri extends ObjectHydrator<Specification.EndpointUri> {
   /**
-   * Instanciates a new instance of the EndpointUri class.
+   * Instantiates a new instance of the EndpointUri class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EndpointUri.

--- a/src/lib/generated/classes/endpoint.ts
+++ b/src/lib/generated/classes/endpoint.ts
@@ -45,7 +45,7 @@ export interface EndpointConstructor {
  */
 export class Endpoint extends ObjectHydrator<Specification.Endpoint> {
   /**
-   * Instanciates a new instance of the Endpoint class.
+   * Instantiates a new instance of the Endpoint class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Endpoint.

--- a/src/lib/generated/classes/error-details.ts
+++ b/src/lib/generated/classes/error-details.ts
@@ -43,7 +43,7 @@ export interface ErrorDetailsConstructor {
  */
 export class ErrorDetails extends ObjectHydrator<Specification.ErrorDetails> {
   /**
-   * Instanciates a new instance of the ErrorDetails class.
+   * Instantiates a new instance of the ErrorDetails class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ErrorDetails.

--- a/src/lib/generated/classes/error-filter.ts
+++ b/src/lib/generated/classes/error-filter.ts
@@ -43,7 +43,7 @@ export interface ErrorFilterConstructor {
  */
 export class ErrorFilter extends ObjectHydrator<Specification.ErrorFilter> {
   /**
-   * Instanciates a new instance of the ErrorFilter class.
+   * Instantiates a new instance of the ErrorFilter class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ErrorFilter.

--- a/src/lib/generated/classes/error-instance.ts
+++ b/src/lib/generated/classes/error-instance.ts
@@ -43,7 +43,7 @@ export interface ErrorInstanceConstructor {
  */
 export class ErrorInstance extends ObjectHydrator<Specification.ErrorInstance> {
   /**
-   * Instanciates a new instance of the ErrorInstance class.
+   * Instantiates a new instance of the ErrorInstance class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ErrorInstance.

--- a/src/lib/generated/classes/error-title.ts
+++ b/src/lib/generated/classes/error-title.ts
@@ -43,7 +43,7 @@ export interface ErrorTitleConstructor {
  */
 export class ErrorTitle extends ObjectHydrator<Specification.ErrorTitle> {
   /**
-   * Instanciates a new instance of the ErrorTitle class.
+   * Instantiates a new instance of the ErrorTitle class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ErrorTitle.

--- a/src/lib/generated/classes/error-type.ts
+++ b/src/lib/generated/classes/error-type.ts
@@ -43,7 +43,7 @@ export interface ErrorTypeConstructor {
  */
 export class ErrorType extends ObjectHydrator<Specification.ErrorType> {
   /**
-   * Instanciates a new instance of the ErrorType class.
+   * Instantiates a new instance of the ErrorType class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ErrorType.

--- a/src/lib/generated/classes/error.ts
+++ b/src/lib/generated/classes/error.ts
@@ -43,7 +43,7 @@ export interface ErrorConstructor {
  */
 export class Error extends ObjectHydrator<Specification.Error> {
   /**
-   * Instanciates a new instance of the Error class.
+   * Instantiates a new instance of the Error class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Error.

--- a/src/lib/generated/classes/event-consumption-strategy.ts
+++ b/src/lib/generated/classes/event-consumption-strategy.ts
@@ -48,7 +48,7 @@ export interface EventConsumptionStrategyConstructor {
  */
 export class EventConsumptionStrategy extends ObjectHydrator<Specification.EventConsumptionStrategy> {
   /**
-   * Instanciates a new instance of the EventConsumptionStrategy class.
+   * Instantiates a new instance of the EventConsumptionStrategy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EventConsumptionStrategy.

--- a/src/lib/generated/classes/event-data.ts
+++ b/src/lib/generated/classes/event-data.ts
@@ -43,7 +43,7 @@ export interface EventDataConstructor {
  */
 export class EventData extends ObjectHydrator<Specification.EventData> {
   /**
-   * Instanciates a new instance of the EventData class.
+   * Instantiates a new instance of the EventData class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EventData.

--- a/src/lib/generated/classes/event-dataschema.ts
+++ b/src/lib/generated/classes/event-dataschema.ts
@@ -43,7 +43,7 @@ export interface EventDataschemaConstructor {
  */
 export class EventDataschema extends ObjectHydrator<Specification.EventDataschema> {
   /**
-   * Instanciates a new instance of the EventDataschema class.
+   * Instantiates a new instance of the EventDataschema class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EventDataschema.

--- a/src/lib/generated/classes/event-filter-correlate.ts
+++ b/src/lib/generated/classes/event-filter-correlate.ts
@@ -43,7 +43,7 @@ export interface EventFilterCorrelateConstructor {
  */
 export class EventFilterCorrelate extends ObjectHydrator<Specification.EventFilterCorrelate> {
   /**
-   * Instanciates a new instance of the EventFilterCorrelate class.
+   * Instantiates a new instance of the EventFilterCorrelate class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EventFilterCorrelate.

--- a/src/lib/generated/classes/event-filter.ts
+++ b/src/lib/generated/classes/event-filter.ts
@@ -46,7 +46,7 @@ export interface EventFilterConstructor {
  */
 export class EventFilter extends ObjectHydrator<Specification.EventFilter> {
   /**
-   * Instanciates a new instance of the EventFilter class.
+   * Instantiates a new instance of the EventFilter class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EventFilter.

--- a/src/lib/generated/classes/event-source.ts
+++ b/src/lib/generated/classes/event-source.ts
@@ -43,7 +43,7 @@ export interface EventSourceConstructor {
  */
 export class EventSource extends ObjectHydrator<Specification.EventSource> {
   /**
-   * Instanciates a new instance of the EventSource class.
+   * Instantiates a new instance of the EventSource class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EventSource.

--- a/src/lib/generated/classes/event-time.ts
+++ b/src/lib/generated/classes/event-time.ts
@@ -43,7 +43,7 @@ export interface EventTimeConstructor {
  */
 export class EventTime extends ObjectHydrator<Specification.EventTime> {
   /**
-   * Instanciates a new instance of the EventTime class.
+   * Instantiates a new instance of the EventTime class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the EventTime.

--- a/src/lib/generated/classes/exponential-back-off.ts
+++ b/src/lib/generated/classes/exponential-back-off.ts
@@ -43,7 +43,7 @@ export interface ExponentialBackOffConstructor {
  */
 export class ExponentialBackOff extends ObjectHydrator<Specification.ExponentialBackOff> {
   /**
-   * Instanciates a new instance of the ExponentialBackOff class.
+   * Instantiates a new instance of the ExponentialBackOff class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ExponentialBackOff.

--- a/src/lib/generated/classes/export-as.ts
+++ b/src/lib/generated/classes/export-as.ts
@@ -43,7 +43,7 @@ export interface ExportAsConstructor {
  */
 export class ExportAs extends ObjectHydrator<Specification.ExportAs> {
   /**
-   * Instanciates a new instance of the ExportAs class.
+   * Instantiates a new instance of the ExportAs class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ExportAs.

--- a/src/lib/generated/classes/export.ts
+++ b/src/lib/generated/classes/export.ts
@@ -45,7 +45,7 @@ export interface ExportConstructor {
  */
 export class Export extends ObjectHydrator<Specification.Export> {
   /**
-   * Instanciates a new instance of the Export class.
+   * Instantiates a new instance of the Export class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Export.

--- a/src/lib/generated/classes/extension-item.ts
+++ b/src/lib/generated/classes/extension-item.ts
@@ -45,7 +45,7 @@ export interface ExtensionItemConstructor {
  */
 export class ExtensionItem extends ObjectHydrator<Specification.ExtensionItem> {
   /**
-   * Instanciates a new instance of the ExtensionItem class.
+   * Instantiates a new instance of the ExtensionItem class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ExtensionItem.

--- a/src/lib/generated/classes/extension.ts
+++ b/src/lib/generated/classes/extension.ts
@@ -45,7 +45,7 @@ export interface ExtensionConstructor {
  */
 export class Extension extends ObjectHydrator<Specification.Extension> {
   /**
-   * Instanciates a new instance of the Extension class.
+   * Instantiates a new instance of the Extension class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Extension.

--- a/src/lib/generated/classes/external-resource.ts
+++ b/src/lib/generated/classes/external-resource.ts
@@ -45,7 +45,7 @@ export interface ExternalResourceConstructor {
  */
 export class ExternalResource extends ObjectHydrator<Specification.ExternalResource> {
   /**
-   * Instanciates a new instance of the ExternalResource class.
+   * Instantiates a new instance of the ExternalResource class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ExternalResource.

--- a/src/lib/generated/classes/external-script.ts
+++ b/src/lib/generated/classes/external-script.ts
@@ -45,7 +45,7 @@ export interface ExternalScriptConstructor {
  */
 export class ExternalScript extends ObjectHydrator<Specification.ExternalScript> {
   /**
-   * Instanciates a new instance of the ExternalScript class.
+   * Instantiates a new instance of the ExternalScript class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ExternalScript.

--- a/src/lib/generated/classes/flow-directive.ts
+++ b/src/lib/generated/classes/flow-directive.ts
@@ -43,7 +43,7 @@ export interface FlowDirectiveConstructor {
  */
 export class FlowDirective extends ObjectHydrator<Specification.FlowDirective> {
   /**
-   * Instanciates a new instance of the FlowDirective class.
+   * Instantiates a new instance of the FlowDirective class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the FlowDirective.

--- a/src/lib/generated/classes/for-task-configuration.ts
+++ b/src/lib/generated/classes/for-task-configuration.ts
@@ -43,7 +43,7 @@ export interface ForTaskConfigurationConstructor {
  */
 export class ForTaskConfiguration extends ObjectHydrator<Specification.ForTaskConfiguration> {
   /**
-   * Instanciates a new instance of the ForTaskConfiguration class.
+   * Instantiates a new instance of the ForTaskConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ForTaskConfiguration.

--- a/src/lib/generated/classes/for-task.ts
+++ b/src/lib/generated/classes/for-task.ts
@@ -51,7 +51,7 @@ export interface ForTaskConstructor {
  */
 export class ForTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the ForTask class.
+   * Instantiates a new instance of the ForTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ForTask.

--- a/src/lib/generated/classes/fork-task-configuration.ts
+++ b/src/lib/generated/classes/fork-task-configuration.ts
@@ -45,7 +45,7 @@ export interface ForkTaskConfigurationConstructor {
  */
 export class ForkTaskConfiguration extends ObjectHydrator<Specification.ForkTaskConfiguration> {
   /**
-   * Instanciates a new instance of the ForkTaskConfiguration class.
+   * Instantiates a new instance of the ForkTaskConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ForkTaskConfiguration.

--- a/src/lib/generated/classes/fork-task.ts
+++ b/src/lib/generated/classes/fork-task.ts
@@ -50,7 +50,7 @@ export interface ForkTaskConstructor {
  */
 export class ForkTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the ForkTask class.
+   * Instantiates a new instance of the ForkTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ForkTask.

--- a/src/lib/generated/classes/function-arguments.ts
+++ b/src/lib/generated/classes/function-arguments.ts
@@ -43,7 +43,7 @@ export interface FunctionArgumentsConstructor {
  */
 export class FunctionArguments extends ObjectHydrator<Specification.FunctionArguments> {
   /**
-   * Instanciates a new instance of the FunctionArguments class.
+   * Instantiates a new instance of the FunctionArguments class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the FunctionArguments.

--- a/src/lib/generated/classes/grpc-arguments.ts
+++ b/src/lib/generated/classes/grpc-arguments.ts
@@ -47,7 +47,7 @@ export interface GRPCArgumentsConstructor {
  */
 export class GRPCArguments extends ObjectHydrator<Specification.GRPCArguments> {
   /**
-   * Instanciates a new instance of the GRPCArguments class.
+   * Instantiates a new instance of the GRPCArguments class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the GRPCArguments.

--- a/src/lib/generated/classes/http-arguments.ts
+++ b/src/lib/generated/classes/http-arguments.ts
@@ -46,7 +46,7 @@ export interface HTTPArgumentsConstructor {
  */
 export class HTTPArguments extends ObjectHydrator<Specification.HTTPArguments> {
   /**
-   * Instanciates a new instance of the HTTPArguments class.
+   * Instantiates a new instance of the HTTPArguments class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the HTTPArguments.

--- a/src/lib/generated/classes/http-body.ts
+++ b/src/lib/generated/classes/http-body.ts
@@ -43,7 +43,7 @@ export interface HTTPBodyConstructor {
  */
 export class HTTPBody extends ObjectHydrator<Specification.HTTPBody> {
   /**
-   * Instanciates a new instance of the HTTPBody class.
+   * Instantiates a new instance of the HTTPBody class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the HTTPBody.

--- a/src/lib/generated/classes/http-headers.ts
+++ b/src/lib/generated/classes/http-headers.ts
@@ -43,7 +43,7 @@ export interface HTTPHeadersConstructor {
  */
 export class HTTPHeaders extends ObjectHydrator<Specification.HTTPHeaders> {
   /**
-   * Instanciates a new instance of the HTTPHeaders class.
+   * Instantiates a new instance of the HTTPHeaders class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the HTTPHeaders.

--- a/src/lib/generated/classes/http-query.ts
+++ b/src/lib/generated/classes/http-query.ts
@@ -43,7 +43,7 @@ export interface HTTPQueryConstructor {
  */
 export class HTTPQuery extends ObjectHydrator<Specification.HTTPQuery> {
   /**
-   * Instanciates a new instance of the HTTPQuery class.
+   * Instantiates a new instance of the HTTPQuery class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the HTTPQuery.

--- a/src/lib/generated/classes/inline-script.ts
+++ b/src/lib/generated/classes/inline-script.ts
@@ -43,7 +43,7 @@ export interface InlineScriptConstructor {
  */
 export class InlineScript extends ObjectHydrator<Specification.InlineScript> {
   /**
-   * Instanciates a new instance of the InlineScript class.
+   * Instantiates a new instance of the InlineScript class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the InlineScript.

--- a/src/lib/generated/classes/input-from.ts
+++ b/src/lib/generated/classes/input-from.ts
@@ -43,7 +43,7 @@ export interface InputFromConstructor {
  */
 export class InputFrom extends ObjectHydrator<Specification.InputFrom> {
   /**
-   * Instanciates a new instance of the InputFrom class.
+   * Instantiates a new instance of the InputFrom class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the InputFrom.

--- a/src/lib/generated/classes/input.ts
+++ b/src/lib/generated/classes/input.ts
@@ -45,7 +45,7 @@ export interface InputConstructor {
  */
 export class Input extends ObjectHydrator<Specification.Input> {
   /**
-   * Instanciates a new instance of the Input class.
+   * Instantiates a new instance of the Input class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Input.

--- a/src/lib/generated/classes/linear-backoff.ts
+++ b/src/lib/generated/classes/linear-backoff.ts
@@ -43,7 +43,7 @@ export interface LinearBackoffConstructor {
  */
 export class LinearBackoff extends ObjectHydrator<Specification.LinearBackoff> {
   /**
-   * Instanciates a new instance of the LinearBackoff class.
+   * Instantiates a new instance of the LinearBackoff class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the LinearBackoff.

--- a/src/lib/generated/classes/listen-task-configuration.ts
+++ b/src/lib/generated/classes/listen-task-configuration.ts
@@ -45,7 +45,7 @@ export interface ListenTaskConfigurationConstructor {
  */
 export class ListenTaskConfiguration extends ObjectHydrator<Specification.ListenTaskConfiguration> {
   /**
-   * Instanciates a new instance of the ListenTaskConfiguration class.
+   * Instantiates a new instance of the ListenTaskConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ListenTaskConfiguration.

--- a/src/lib/generated/classes/listen-task.ts
+++ b/src/lib/generated/classes/listen-task.ts
@@ -51,7 +51,7 @@ export interface ListenTaskConstructor {
  */
 export class ListenTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the ListenTask class.
+   * Instantiates a new instance of the ListenTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ListenTask.

--- a/src/lib/generated/classes/mcp-arguments.ts
+++ b/src/lib/generated/classes/mcp-arguments.ts
@@ -46,7 +46,7 @@ export interface MCPArgumentsConstructor {
  */
 export class MCPArguments extends ObjectHydrator<Specification.MCPArguments> {
   /**
-   * Instanciates a new instance of the MCPArguments class.
+   * Instantiates a new instance of the MCPArguments class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the MCPArguments.

--- a/src/lib/generated/classes/mcp-call-transport.ts
+++ b/src/lib/generated/classes/mcp-call-transport.ts
@@ -43,7 +43,7 @@ export interface McpCallTransportConstructor {
  */
 export class McpCallTransport extends ObjectHydrator<Specification.McpCallTransport> {
   /**
-   * Instanciates a new instance of the McpCallTransport class.
+   * Instantiates a new instance of the McpCallTransport class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the McpCallTransport.

--- a/src/lib/generated/classes/mcp-client.ts
+++ b/src/lib/generated/classes/mcp-client.ts
@@ -43,7 +43,7 @@ export interface McpClientConstructor {
  */
 export class McpClient extends ObjectHydrator<Specification.McpClient> {
   /**
-   * Instanciates a new instance of the McpClient class.
+   * Instantiates a new instance of the McpClient class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the McpClient.

--- a/src/lib/generated/classes/mcp-method-parameters.ts
+++ b/src/lib/generated/classes/mcp-method-parameters.ts
@@ -43,7 +43,7 @@ export interface McpMethodParametersConstructor {
  */
 export class McpMethodParameters extends ObjectHydrator<Specification.McpMethodParameters> {
   /**
-   * Instanciates a new instance of the McpMethodParameters class.
+   * Instantiates a new instance of the McpMethodParameters class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the McpMethodParameters.

--- a/src/lib/generated/classes/oauth2-authentication-data-client.ts
+++ b/src/lib/generated/classes/oauth2-authentication-data-client.ts
@@ -44,7 +44,7 @@ export interface OAuth2AuthenticationDataClientConstructor {
  */
 export class OAuth2AuthenticationDataClient extends ObjectHydrator<Specification.OAuth2AuthenticationDataClient> {
   /**
-   * Instanciates a new instance of the OAuth2AuthenticationDataClient class.
+   * Instantiates a new instance of the OAuth2AuthenticationDataClient class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OAuth2AuthenticationDataClient.

--- a/src/lib/generated/classes/oauth2-authentication-data.ts
+++ b/src/lib/generated/classes/oauth2-authentication-data.ts
@@ -47,7 +47,7 @@ export interface OAuth2AuthenticationDataConstructor {
  */
 export class OAuth2AuthenticationData extends ObjectHydrator<Specification.OAuth2AuthenticationData> {
   /**
-   * Instanciates a new instance of the OAuth2AuthenticationData class.
+   * Instantiates a new instance of the OAuth2AuthenticationData class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OAuth2AuthenticationData.

--- a/src/lib/generated/classes/oauth2-authentication-policy-configuration.ts
+++ b/src/lib/generated/classes/oauth2-authentication-policy-configuration.ts
@@ -51,7 +51,7 @@ export interface OAuth2AuthenticationPolicyConfigurationConstructor {
  */
 export class OAuth2AuthenticationPolicyConfiguration extends ObjectHydrator<Specification.OAuth2AuthenticationPolicyConfiguration> {
   /**
-   * Instanciates a new instance of the OAuth2AuthenticationPolicyConfiguration class.
+   * Instantiates a new instance of the OAuth2AuthenticationPolicyConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OAuth2AuthenticationPolicyConfiguration.

--- a/src/lib/generated/classes/oauth2-authentication-policy.ts
+++ b/src/lib/generated/classes/oauth2-authentication-policy.ts
@@ -46,7 +46,7 @@ export interface OAuth2AuthenticationPolicyConstructor {
  */
 export class OAuth2AuthenticationPolicy extends ObjectHydrator<Specification.OAuth2AuthenticationPolicy> {
   /**
-   * Instanciates a new instance of the OAuth2AuthenticationPolicy class.
+   * Instantiates a new instance of the OAuth2AuthenticationPolicy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OAuth2AuthenticationPolicy.

--- a/src/lib/generated/classes/oauth2-authentication-properties-endpoints.ts
+++ b/src/lib/generated/classes/oauth2-authentication-properties-endpoints.ts
@@ -46,7 +46,7 @@ export interface OAuth2AuthenticationPropertiesEndpointsConstructor {
  */
 export class OAuth2AuthenticationPropertiesEndpoints extends ObjectHydrator<Specification.OAuth2AuthenticationPropertiesEndpoints> {
   /**
-   * Instanciates a new instance of the OAuth2AuthenticationPropertiesEndpoints class.
+   * Instantiates a new instance of the OAuth2AuthenticationPropertiesEndpoints class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OAuth2AuthenticationPropertiesEndpoints.

--- a/src/lib/generated/classes/oauth2-connect-authentication-properties.ts
+++ b/src/lib/generated/classes/oauth2-connect-authentication-properties.ts
@@ -51,7 +51,7 @@ export interface OAuth2ConnectAuthenticationPropertiesConstructor {
  */
 export class OAuth2ConnectAuthenticationProperties extends _OAuth2AuthenticationData {
   /**
-   * Instanciates a new instance of the OAuth2ConnectAuthenticationProperties class.
+   * Instantiates a new instance of the OAuth2ConnectAuthenticationProperties class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OAuth2ConnectAuthenticationProperties.

--- a/src/lib/generated/classes/oauth2-token-definition.ts
+++ b/src/lib/generated/classes/oauth2-token-definition.ts
@@ -43,7 +43,7 @@ export interface OAuth2TokenDefinitionConstructor {
  */
 export class OAuth2TokenDefinition extends ObjectHydrator<Specification.OAuth2TokenDefinition> {
   /**
-   * Instanciates a new instance of the OAuth2TokenDefinition class.
+   * Instantiates a new instance of the OAuth2TokenDefinition class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OAuth2TokenDefinition.

--- a/src/lib/generated/classes/oauth2-token-request.ts
+++ b/src/lib/generated/classes/oauth2-token-request.ts
@@ -43,7 +43,7 @@ export interface OAuth2TokenRequestConstructor {
  */
 export class OAuth2TokenRequest extends ObjectHydrator<Specification.OAuth2TokenRequest> {
   /**
-   * Instanciates a new instance of the OAuth2TokenRequest class.
+   * Instantiates a new instance of the OAuth2TokenRequest class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OAuth2TokenRequest.

--- a/src/lib/generated/classes/one-event-consumption-strategy.ts
+++ b/src/lib/generated/classes/one-event-consumption-strategy.ts
@@ -46,7 +46,7 @@ export interface OneEventConsumptionStrategyConstructor {
  */
 export class OneEventConsumptionStrategy extends ObjectHydrator<Specification.OneEventConsumptionStrategy> {
   /**
-   * Instanciates a new instance of the OneEventConsumptionStrategy class.
+   * Instantiates a new instance of the OneEventConsumptionStrategy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OneEventConsumptionStrategy.

--- a/src/lib/generated/classes/open-api-arguments.ts
+++ b/src/lib/generated/classes/open-api-arguments.ts
@@ -47,7 +47,7 @@ export interface OpenAPIArgumentsConstructor {
  */
 export class OpenAPIArguments extends ObjectHydrator<Specification.OpenAPIArguments> {
   /**
-   * Instanciates a new instance of the OpenAPIArguments class.
+   * Instantiates a new instance of the OpenAPIArguments class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OpenAPIArguments.

--- a/src/lib/generated/classes/open-id-connect-authentication-policy-configuration.ts
+++ b/src/lib/generated/classes/open-id-connect-authentication-policy-configuration.ts
@@ -50,7 +50,7 @@ export interface OpenIdConnectAuthenticationPolicyConfigurationConstructor {
  */
 export class OpenIdConnectAuthenticationPolicyConfiguration extends ObjectHydrator<Specification.OpenIdConnectAuthenticationPolicyConfiguration> {
   /**
-   * Instanciates a new instance of the OpenIdConnectAuthenticationPolicyConfiguration class.
+   * Instantiates a new instance of the OpenIdConnectAuthenticationPolicyConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OpenIdConnectAuthenticationPolicyConfiguration.

--- a/src/lib/generated/classes/open-id-connect-authentication-policy.ts
+++ b/src/lib/generated/classes/open-id-connect-authentication-policy.ts
@@ -46,7 +46,7 @@ export interface OpenIdConnectAuthenticationPolicyConstructor {
  */
 export class OpenIdConnectAuthenticationPolicy extends ObjectHydrator<Specification.OpenIdConnectAuthenticationPolicy> {
   /**
-   * Instanciates a new instance of the OpenIdConnectAuthenticationPolicy class.
+   * Instantiates a new instance of the OpenIdConnectAuthenticationPolicy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OpenIdConnectAuthenticationPolicy.

--- a/src/lib/generated/classes/open-id-connect-authentication-properties.ts
+++ b/src/lib/generated/classes/open-id-connect-authentication-properties.ts
@@ -50,7 +50,7 @@ export interface OpenIdConnectAuthenticationPropertiesConstructor {
  */
 export class OpenIdConnectAuthenticationProperties extends ObjectHydrator<Specification.OpenIdConnectAuthenticationProperties> {
   /**
-   * Instanciates a new instance of the OpenIdConnectAuthenticationProperties class.
+   * Instantiates a new instance of the OpenIdConnectAuthenticationProperties class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OpenIdConnectAuthenticationProperties.

--- a/src/lib/generated/classes/output-as.ts
+++ b/src/lib/generated/classes/output-as.ts
@@ -43,7 +43,7 @@ export interface OutputAsConstructor {
  */
 export class OutputAs extends ObjectHydrator<Specification.OutputAs> {
   /**
-   * Instanciates a new instance of the OutputAs class.
+   * Instantiates a new instance of the OutputAs class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the OutputAs.

--- a/src/lib/generated/classes/output.ts
+++ b/src/lib/generated/classes/output.ts
@@ -45,7 +45,7 @@ export interface OutputConstructor {
  */
 export class Output extends ObjectHydrator<Specification.Output> {
   /**
-   * Instanciates a new instance of the Output class.
+   * Instantiates a new instance of the Output class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Output.

--- a/src/lib/generated/classes/raise-task-configuration.ts
+++ b/src/lib/generated/classes/raise-task-configuration.ts
@@ -45,7 +45,7 @@ export interface RaiseTaskConfigurationConstructor {
  */
 export class RaiseTaskConfiguration extends ObjectHydrator<Specification.RaiseTaskConfiguration> {
   /**
-   * Instanciates a new instance of the RaiseTaskConfiguration class.
+   * Instantiates a new instance of the RaiseTaskConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RaiseTaskConfiguration.

--- a/src/lib/generated/classes/raise-task-error.ts
+++ b/src/lib/generated/classes/raise-task-error.ts
@@ -43,7 +43,7 @@ export interface RaiseTaskErrorConstructor {
  */
 export class RaiseTaskError extends ObjectHydrator<Specification.RaiseTaskError> {
   /**
-   * Instanciates a new instance of the RaiseTaskError class.
+   * Instantiates a new instance of the RaiseTaskError class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RaiseTaskError.

--- a/src/lib/generated/classes/raise-task.ts
+++ b/src/lib/generated/classes/raise-task.ts
@@ -50,7 +50,7 @@ export interface RaiseTaskConstructor {
  */
 export class RaiseTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the RaiseTask class.
+   * Instantiates a new instance of the RaiseTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RaiseTask.

--- a/src/lib/generated/classes/referenceable-authentication-policy.ts
+++ b/src/lib/generated/classes/referenceable-authentication-policy.ts
@@ -50,7 +50,7 @@ export interface ReferenceableAuthenticationPolicyConstructor {
  */
 export class ReferenceableAuthenticationPolicy extends ObjectHydrator<Specification.ReferenceableAuthenticationPolicy> {
   /**
-   * Instanciates a new instance of the ReferenceableAuthenticationPolicy class.
+   * Instantiates a new instance of the ReferenceableAuthenticationPolicy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ReferenceableAuthenticationPolicy.

--- a/src/lib/generated/classes/retry-backoff.ts
+++ b/src/lib/generated/classes/retry-backoff.ts
@@ -43,7 +43,7 @@ export interface RetryBackoffConstructor {
  */
 export class RetryBackoff extends ObjectHydrator<Specification.RetryBackoff> {
   /**
-   * Instanciates a new instance of the RetryBackoff class.
+   * Instantiates a new instance of the RetryBackoff class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RetryBackoff.

--- a/src/lib/generated/classes/retry-limit-attempt.ts
+++ b/src/lib/generated/classes/retry-limit-attempt.ts
@@ -45,7 +45,7 @@ export interface RetryLimitAttemptConstructor {
  */
 export class RetryLimitAttempt extends ObjectHydrator<Specification.RetryLimitAttempt> {
   /**
-   * Instanciates a new instance of the RetryLimitAttempt class.
+   * Instantiates a new instance of the RetryLimitAttempt class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RetryLimitAttempt.

--- a/src/lib/generated/classes/retry-limit.ts
+++ b/src/lib/generated/classes/retry-limit.ts
@@ -46,7 +46,7 @@ export interface RetryLimitConstructor {
  */
 export class RetryLimit extends ObjectHydrator<Specification.RetryLimit> {
   /**
-   * Instanciates a new instance of the RetryLimit class.
+   * Instantiates a new instance of the RetryLimit class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RetryLimit.

--- a/src/lib/generated/classes/retry-policy-jitter.ts
+++ b/src/lib/generated/classes/retry-policy-jitter.ts
@@ -45,7 +45,7 @@ export interface RetryPolicyJitterConstructor {
  */
 export class RetryPolicyJitter extends ObjectHydrator<Specification.RetryPolicyJitter> {
   /**
-   * Instanciates a new instance of the RetryPolicyJitter class.
+   * Instantiates a new instance of the RetryPolicyJitter class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RetryPolicyJitter.

--- a/src/lib/generated/classes/retry-policy.ts
+++ b/src/lib/generated/classes/retry-policy.ts
@@ -48,7 +48,7 @@ export interface RetryPolicyConstructor {
  */
 export class RetryPolicy extends ObjectHydrator<Specification.RetryPolicy> {
   /**
-   * Instanciates a new instance of the RetryPolicy class.
+   * Instantiates a new instance of the RetryPolicy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RetryPolicy.

--- a/src/lib/generated/classes/run-container.ts
+++ b/src/lib/generated/classes/run-container.ts
@@ -45,7 +45,7 @@ export interface RunContainerConstructor {
  */
 export class RunContainer extends ObjectHydrator<Specification.RunContainer> {
   /**
-   * Instanciates a new instance of the RunContainer class.
+   * Instantiates a new instance of the RunContainer class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RunContainer.

--- a/src/lib/generated/classes/run-script.ts
+++ b/src/lib/generated/classes/run-script.ts
@@ -45,7 +45,7 @@ export interface RunScriptConstructor {
  */
 export class RunScript extends ObjectHydrator<Specification.RunScript> {
   /**
-   * Instanciates a new instance of the RunScript class.
+   * Instantiates a new instance of the RunScript class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RunScript.

--- a/src/lib/generated/classes/run-shell.ts
+++ b/src/lib/generated/classes/run-shell.ts
@@ -45,7 +45,7 @@ export interface RunShellConstructor {
  */
 export class RunShell extends ObjectHydrator<Specification.RunShell> {
   /**
-   * Instanciates a new instance of the RunShell class.
+   * Instantiates a new instance of the RunShell class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RunShell.

--- a/src/lib/generated/classes/run-task-configuration.ts
+++ b/src/lib/generated/classes/run-task-configuration.ts
@@ -48,7 +48,7 @@ export interface RunTaskConfigurationConstructor {
  */
 export class RunTaskConfiguration extends ObjectHydrator<Specification.RunTaskConfiguration> {
   /**
-   * Instanciates a new instance of the RunTaskConfiguration class.
+   * Instantiates a new instance of the RunTaskConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RunTaskConfiguration.

--- a/src/lib/generated/classes/run-task.ts
+++ b/src/lib/generated/classes/run-task.ts
@@ -50,7 +50,7 @@ export interface RunTaskConstructor {
  */
 export class RunTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the RunTask class.
+   * Instantiates a new instance of the RunTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RunTask.

--- a/src/lib/generated/classes/run-workflow.ts
+++ b/src/lib/generated/classes/run-workflow.ts
@@ -45,7 +45,7 @@ export interface RunWorkflowConstructor {
  */
 export class RunWorkflow extends ObjectHydrator<Specification.RunWorkflow> {
   /**
-   * Instanciates a new instance of the RunWorkflow class.
+   * Instantiates a new instance of the RunWorkflow class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RunWorkflow.

--- a/src/lib/generated/classes/runtime-expression.ts
+++ b/src/lib/generated/classes/runtime-expression.ts
@@ -43,7 +43,7 @@ export interface RuntimeExpressionConstructor {
  */
 export class RuntimeExpression extends ObjectHydrator<Specification.RuntimeExpression> {
   /**
-   * Instanciates a new instance of the RuntimeExpression class.
+   * Instantiates a new instance of the RuntimeExpression class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the RuntimeExpression.

--- a/src/lib/generated/classes/schedule.ts
+++ b/src/lib/generated/classes/schedule.ts
@@ -46,7 +46,7 @@ export interface ScheduleConstructor {
  */
 export class Schedule extends ObjectHydrator<Specification.Schedule> {
   /**
-   * Instanciates a new instance of the Schedule class.
+   * Instantiates a new instance of the Schedule class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Schedule.

--- a/src/lib/generated/classes/schema-external.ts
+++ b/src/lib/generated/classes/schema-external.ts
@@ -45,7 +45,7 @@ export interface SchemaExternalConstructor {
  */
 export class SchemaExternal extends ObjectHydrator<Specification.SchemaExternal> {
   /**
-   * Instanciates a new instance of the SchemaExternal class.
+   * Instantiates a new instance of the SchemaExternal class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SchemaExternal.

--- a/src/lib/generated/classes/schema-inline.ts
+++ b/src/lib/generated/classes/schema-inline.ts
@@ -43,7 +43,7 @@ export interface SchemaInlineConstructor {
  */
 export class SchemaInline extends ObjectHydrator<Specification.SchemaInline> {
   /**
-   * Instanciates a new instance of the SchemaInline class.
+   * Instantiates a new instance of the SchemaInline class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SchemaInline.

--- a/src/lib/generated/classes/schema.ts
+++ b/src/lib/generated/classes/schema.ts
@@ -45,7 +45,7 @@ export interface SchemaConstructor {
  */
 export class Schema extends ObjectHydrator<Specification.Schema> {
   /**
-   * Instanciates a new instance of the Schema class.
+   * Instantiates a new instance of the Schema class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Schema.

--- a/src/lib/generated/classes/script.ts
+++ b/src/lib/generated/classes/script.ts
@@ -45,7 +45,7 @@ export interface ScriptConstructor {
  */
 export class Script extends ObjectHydrator<Specification.Script> {
   /**
-   * Instanciates a new instance of the Script class.
+   * Instantiates a new instance of the Script class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Script.

--- a/src/lib/generated/classes/secret-based-authentication-policy.ts
+++ b/src/lib/generated/classes/secret-based-authentication-policy.ts
@@ -44,7 +44,7 @@ export interface SecretBasedAuthenticationPolicyConstructor {
  */
 export class SecretBasedAuthenticationPolicy extends ObjectHydrator<Specification.SecretBasedAuthenticationPolicy> {
   /**
-   * Instanciates a new instance of the SecretBasedAuthenticationPolicy class.
+   * Instantiates a new instance of the SecretBasedAuthenticationPolicy class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SecretBasedAuthenticationPolicy.

--- a/src/lib/generated/classes/set-task-configuration.ts
+++ b/src/lib/generated/classes/set-task-configuration.ts
@@ -43,7 +43,7 @@ export interface SetTaskConfigurationConstructor {
  */
 export class SetTaskConfiguration extends ObjectHydrator<Specification.SetTaskConfiguration> {
   /**
-   * Instanciates a new instance of the SetTaskConfiguration class.
+   * Instantiates a new instance of the SetTaskConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SetTaskConfiguration.

--- a/src/lib/generated/classes/set-task.ts
+++ b/src/lib/generated/classes/set-task.ts
@@ -49,7 +49,7 @@ export interface SetTaskConstructor {
  */
 export class SetTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the SetTask class.
+   * Instantiates a new instance of the SetTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SetTask.

--- a/src/lib/generated/classes/shell-environment.ts
+++ b/src/lib/generated/classes/shell-environment.ts
@@ -43,7 +43,7 @@ export interface ShellEnvironmentConstructor {
  */
 export class ShellEnvironment extends ObjectHydrator<Specification.ShellEnvironment> {
   /**
-   * Instanciates a new instance of the ShellEnvironment class.
+   * Instantiates a new instance of the ShellEnvironment class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ShellEnvironment.

--- a/src/lib/generated/classes/shell.ts
+++ b/src/lib/generated/classes/shell.ts
@@ -45,7 +45,7 @@ export interface ShellConstructor {
  */
 export class Shell extends ObjectHydrator<Specification.Shell> {
   /**
-   * Instanciates a new instance of the Shell class.
+   * Instantiates a new instance of the Shell class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Shell.

--- a/src/lib/generated/classes/subflow-configuration.ts
+++ b/src/lib/generated/classes/subflow-configuration.ts
@@ -45,7 +45,7 @@ export interface SubflowConfigurationConstructor {
  */
 export class SubflowConfiguration extends ObjectHydrator<Specification.SubflowConfiguration> {
   /**
-   * Instanciates a new instance of the SubflowConfiguration class.
+   * Instantiates a new instance of the SubflowConfiguration class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SubflowConfiguration.

--- a/src/lib/generated/classes/subflow-input.ts
+++ b/src/lib/generated/classes/subflow-input.ts
@@ -43,7 +43,7 @@ export interface SubflowInputConstructor {
  */
 export class SubflowInput extends ObjectHydrator<Specification.SubflowInput> {
   /**
-   * Instanciates a new instance of the SubflowInput class.
+   * Instantiates a new instance of the SubflowInput class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SubflowInput.

--- a/src/lib/generated/classes/subscription-iterator.ts
+++ b/src/lib/generated/classes/subscription-iterator.ts
@@ -47,7 +47,7 @@ export interface SubscriptionIteratorConstructor {
  */
 export class SubscriptionIterator extends ObjectHydrator<Specification.SubscriptionIterator> {
   /**
-   * Instanciates a new instance of the SubscriptionIterator class.
+   * Instantiates a new instance of the SubscriptionIterator class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SubscriptionIterator.

--- a/src/lib/generated/classes/switch-case.ts
+++ b/src/lib/generated/classes/switch-case.ts
@@ -43,7 +43,7 @@ export interface SwitchCaseConstructor {
  */
 export class SwitchCase extends ObjectHydrator<Specification.SwitchCase> {
   /**
-   * Instanciates a new instance of the SwitchCase class.
+   * Instantiates a new instance of the SwitchCase class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SwitchCase.

--- a/src/lib/generated/classes/switch-item.ts
+++ b/src/lib/generated/classes/switch-item.ts
@@ -45,7 +45,7 @@ export interface SwitchItemConstructor {
  */
 export class SwitchItem extends ObjectHydrator<Specification.SwitchItem> {
   /**
-   * Instanciates a new instance of the SwitchItem class.
+   * Instantiates a new instance of the SwitchItem class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SwitchItem.

--- a/src/lib/generated/classes/switch-task.ts
+++ b/src/lib/generated/classes/switch-task.ts
@@ -50,7 +50,7 @@ export interface SwitchTaskConstructor {
  */
 export class SwitchTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the SwitchTask class.
+   * Instantiates a new instance of the SwitchTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the SwitchTask.

--- a/src/lib/generated/classes/task-base-if.ts
+++ b/src/lib/generated/classes/task-base-if.ts
@@ -43,7 +43,7 @@ export interface TaskBaseIfConstructor {
  */
 export class TaskBaseIf extends ObjectHydrator<Specification.TaskBaseIf> {
   /**
-   * Instanciates a new instance of the TaskBaseIf class.
+   * Instantiates a new instance of the TaskBaseIf class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the TaskBaseIf.

--- a/src/lib/generated/classes/task-base.ts
+++ b/src/lib/generated/classes/task-base.ts
@@ -49,7 +49,7 @@ export interface TaskBaseConstructor {
  */
 export class TaskBase extends ObjectHydrator<Specification.TaskBase> {
   /**
-   * Instanciates a new instance of the TaskBase class.
+   * Instantiates a new instance of the TaskBase class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the TaskBase.

--- a/src/lib/generated/classes/task-item.ts
+++ b/src/lib/generated/classes/task-item.ts
@@ -45,7 +45,7 @@ export interface TaskItemConstructor {
  */
 export class TaskItem extends ObjectHydrator<Specification.TaskItem> {
   /**
-   * Instanciates a new instance of the TaskItem class.
+   * Instantiates a new instance of the TaskItem class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the TaskItem.

--- a/src/lib/generated/classes/task-metadata.ts
+++ b/src/lib/generated/classes/task-metadata.ts
@@ -43,7 +43,7 @@ export interface TaskMetadataConstructor {
  */
 export class TaskMetadata extends ObjectHydrator<Specification.TaskMetadata> {
   /**
-   * Instanciates a new instance of the TaskMetadata class.
+   * Instantiates a new instance of the TaskMetadata class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the TaskMetadata.

--- a/src/lib/generated/classes/task-timeout.ts
+++ b/src/lib/generated/classes/task-timeout.ts
@@ -45,7 +45,7 @@ export interface TaskTimeoutConstructor {
  */
 export class TaskTimeout extends ObjectHydrator<Specification.TaskTimeout> {
   /**
-   * Instanciates a new instance of the TaskTimeout class.
+   * Instantiates a new instance of the TaskTimeout class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the TaskTimeout.

--- a/src/lib/generated/classes/task.ts
+++ b/src/lib/generated/classes/task.ts
@@ -60,7 +60,7 @@ export interface TaskConstructor {
  */
 export class Task extends ObjectHydrator<Specification.Task> {
   /**
-   * Instanciates a new instance of the Task class.
+   * Instantiates a new instance of the Task class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Task.

--- a/src/lib/generated/classes/timeout.ts
+++ b/src/lib/generated/classes/timeout.ts
@@ -45,7 +45,7 @@ export interface TimeoutConstructor {
  */
 export class Timeout extends ObjectHydrator<Specification.Timeout> {
   /**
-   * Instanciates a new instance of the Timeout class.
+   * Instantiates a new instance of the Timeout class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Timeout.

--- a/src/lib/generated/classes/try-task-catch-retry.ts
+++ b/src/lib/generated/classes/try-task-catch-retry.ts
@@ -48,7 +48,7 @@ export interface TryTaskCatchRetryConstructor {
  */
 export class TryTaskCatchRetry extends ObjectHydrator<Specification.TryTaskCatchRetry> {
   /**
-   * Instanciates a new instance of the TryTaskCatchRetry class.
+   * Instantiates a new instance of the TryTaskCatchRetry class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the TryTaskCatchRetry.

--- a/src/lib/generated/classes/try-task-catch.ts
+++ b/src/lib/generated/classes/try-task-catch.ts
@@ -47,7 +47,7 @@ export interface TryTaskCatchConstructor {
  */
 export class TryTaskCatch extends ObjectHydrator<Specification.TryTaskCatch> {
   /**
-   * Instanciates a new instance of the TryTaskCatch class.
+   * Instantiates a new instance of the TryTaskCatch class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the TryTaskCatch.

--- a/src/lib/generated/classes/try-task.ts
+++ b/src/lib/generated/classes/try-task.ts
@@ -51,7 +51,7 @@ export interface TryTaskConstructor {
  */
 export class TryTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the TryTask class.
+   * Instantiates a new instance of the TryTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the TryTask.

--- a/src/lib/generated/classes/uri-template.ts
+++ b/src/lib/generated/classes/uri-template.ts
@@ -43,7 +43,7 @@ export interface UriTemplateConstructor {
  */
 export class UriTemplate extends ObjectHydrator<Specification.UriTemplate> {
   /**
-   * Instanciates a new instance of the UriTemplate class.
+   * Instantiates a new instance of the UriTemplate class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the UriTemplate.

--- a/src/lib/generated/classes/use-authentications.ts
+++ b/src/lib/generated/classes/use-authentications.ts
@@ -45,7 +45,7 @@ export interface UseAuthenticationsConstructor {
  */
 export class UseAuthentications extends ObjectHydrator<Specification.UseAuthentications> {
   /**
-   * Instanciates a new instance of the UseAuthentications class.
+   * Instantiates a new instance of the UseAuthentications class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the UseAuthentications.

--- a/src/lib/generated/classes/use-catalogs.ts
+++ b/src/lib/generated/classes/use-catalogs.ts
@@ -45,7 +45,7 @@ export interface UseCatalogsConstructor {
  */
 export class UseCatalogs extends ObjectHydrator<Specification.UseCatalogs> {
   /**
-   * Instanciates a new instance of the UseCatalogs class.
+   * Instantiates a new instance of the UseCatalogs class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the UseCatalogs.

--- a/src/lib/generated/classes/use-errors.ts
+++ b/src/lib/generated/classes/use-errors.ts
@@ -45,7 +45,7 @@ export interface UseErrorsConstructor {
  */
 export class UseErrors extends ObjectHydrator<Specification.UseErrors> {
   /**
-   * Instanciates a new instance of the UseErrors class.
+   * Instantiates a new instance of the UseErrors class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the UseErrors.

--- a/src/lib/generated/classes/use-functions.ts
+++ b/src/lib/generated/classes/use-functions.ts
@@ -45,7 +45,7 @@ export interface UseFunctionsConstructor {
  */
 export class UseFunctions extends ObjectHydrator<Specification.UseFunctions> {
   /**
-   * Instanciates a new instance of the UseFunctions class.
+   * Instantiates a new instance of the UseFunctions class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the UseFunctions.

--- a/src/lib/generated/classes/use-retries.ts
+++ b/src/lib/generated/classes/use-retries.ts
@@ -45,7 +45,7 @@ export interface UseRetriesConstructor {
  */
 export class UseRetries extends ObjectHydrator<Specification.UseRetries> {
   /**
-   * Instanciates a new instance of the UseRetries class.
+   * Instantiates a new instance of the UseRetries class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the UseRetries.

--- a/src/lib/generated/classes/use-timeouts.ts
+++ b/src/lib/generated/classes/use-timeouts.ts
@@ -45,7 +45,7 @@ export interface UseTimeoutsConstructor {
  */
 export class UseTimeouts extends ObjectHydrator<Specification.UseTimeouts> {
   /**
-   * Instanciates a new instance of the UseTimeouts class.
+   * Instantiates a new instance of the UseTimeouts class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the UseTimeouts.

--- a/src/lib/generated/classes/use.ts
+++ b/src/lib/generated/classes/use.ts
@@ -51,7 +51,7 @@ export interface UseConstructor {
  */
 export class Use extends ObjectHydrator<Specification.Use> {
   /**
-   * Instanciates a new instance of the Use class.
+   * Instantiates a new instance of the Use class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Use.

--- a/src/lib/generated/classes/wait-task.ts
+++ b/src/lib/generated/classes/wait-task.ts
@@ -50,7 +50,7 @@ export interface WaitTaskConstructor {
  */
 export class WaitTask extends _TaskBase {
   /**
-   * Instanciates a new instance of the WaitTask class.
+   * Instantiates a new instance of the WaitTask class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the WaitTask.

--- a/src/lib/generated/classes/with-a2a-parameters.ts
+++ b/src/lib/generated/classes/with-a2a-parameters.ts
@@ -43,7 +43,7 @@ export interface WithA2AParametersConstructor {
  */
 export class WithA2AParameters extends ObjectHydrator<Specification.WithA2AParameters> {
   /**
-   * Instanciates a new instance of the WithA2AParameters class.
+   * Instantiates a new instance of the WithA2AParameters class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the WithA2AParameters.

--- a/src/lib/generated/classes/with-event.ts
+++ b/src/lib/generated/classes/with-event.ts
@@ -43,7 +43,7 @@ export interface WithEventConstructor {
  */
 export class WithEvent extends ObjectHydrator<Specification.WithEvent> {
   /**
-   * Instanciates a new instance of the WithEvent class.
+   * Instantiates a new instance of the WithEvent class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the WithEvent.

--- a/src/lib/generated/classes/with-grpc-arguments.ts
+++ b/src/lib/generated/classes/with-grpc-arguments.ts
@@ -43,7 +43,7 @@ export interface WithGRPCArgumentsConstructor {
  */
 export class WithGRPCArguments extends ObjectHydrator<Specification.WithGRPCArguments> {
   /**
-   * Instanciates a new instance of the WithGRPCArguments class.
+   * Instantiates a new instance of the WithGRPCArguments class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the WithGRPCArguments.

--- a/src/lib/generated/classes/with-grpc-service.ts
+++ b/src/lib/generated/classes/with-grpc-service.ts
@@ -45,7 +45,7 @@ export interface WithGRPCServiceConstructor {
  */
 export class WithGRPCService extends ObjectHydrator<Specification.WithGRPCService> {
   /**
-   * Instanciates a new instance of the WithGRPCService class.
+   * Instantiates a new instance of the WithGRPCService class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the WithGRPCService.

--- a/src/lib/generated/classes/with-open-api-parameters.ts
+++ b/src/lib/generated/classes/with-open-api-parameters.ts
@@ -43,7 +43,7 @@ export interface WithOpenAPIParametersConstructor {
  */
 export class WithOpenAPIParameters extends ObjectHydrator<Specification.WithOpenAPIParameters> {
   /**
-   * Instanciates a new instance of the WithOpenAPIParameters class.
+   * Instantiates a new instance of the WithOpenAPIParameters class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the WithOpenAPIParameters.

--- a/src/lib/generated/classes/workflow-metadata.ts
+++ b/src/lib/generated/classes/workflow-metadata.ts
@@ -43,7 +43,7 @@ export interface WorkflowMetadataConstructor {
  */
 export class WorkflowMetadata extends ObjectHydrator<Specification.WorkflowMetadata> {
   /**
-   * Instanciates a new instance of the WorkflowMetadata class.
+   * Instantiates a new instance of the WorkflowMetadata class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the WorkflowMetadata.

--- a/src/lib/generated/classes/workflow-tags.ts
+++ b/src/lib/generated/classes/workflow-tags.ts
@@ -43,7 +43,7 @@ export interface WorkflowTagsConstructor {
  */
 export class WorkflowTags extends ObjectHydrator<Specification.WorkflowTags> {
   /**
-   * Instanciates a new instance of the WorkflowTags class.
+   * Instantiates a new instance of the WorkflowTags class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the WorkflowTags.

--- a/src/lib/generated/classes/workflow-timeout.ts
+++ b/src/lib/generated/classes/workflow-timeout.ts
@@ -45,7 +45,7 @@ export interface WorkflowTimeoutConstructor {
  */
 export class WorkflowTimeout extends ObjectHydrator<Specification.WorkflowTimeout> {
   /**
-   * Instanciates a new instance of the WorkflowTimeout class.
+   * Instantiates a new instance of the WorkflowTimeout class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the WorkflowTimeout.

--- a/src/lib/generated/classes/workflow.ts
+++ b/src/lib/generated/classes/workflow.ts
@@ -60,7 +60,7 @@ export interface WorkflowConstructor {
  */
 export class Workflow extends ObjectHydrator<Specification.Workflow> {
   /**
-   * Instanciates a new instance of the Workflow class.
+   * Instantiates a new instance of the Workflow class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the Workflow.

--- a/src/lib/hydrator.ts
+++ b/src/lib/hydrator.ts
@@ -22,7 +22,7 @@ import { deepCopy, isObject } from './utils';
  */
 export class ObjectHydrator<T> {
   /**
-   * Instanciates a new instance of the ObjectHydrator class.
+   * Instantiates a new instance of the ObjectHydrator class.
    * Copies the own properties of the provided model onto the instance if it is an object.
    *
    * @param model - Optional partial model object to initialize the instance.
@@ -53,7 +53,7 @@ export class ObjectHydrator<T> {
  */
 export class ArrayHydrator<T> extends Array<T> {
   /**
-   * Instanciates a new instance of the ArrayHydrator class.
+   * Instantiates a new instance of the ArrayHydrator class.
    * Copies the elements of the provided model onto the instance if it is an array.
    *
    * Discriminates on the model's runtime type rather than on its numeric coercion. `Number([])` is 0

--- a/tools/4_generate-classes.ts
+++ b/tools/4_generate-classes.ts
@@ -78,7 +78,7 @@ export interface ${name}Constructor {
  */
 export class ${name} extends ${baseClass ? '_' + baseClass : `ObjectHydrator<Specification.${name}>`} {
   /**
-   * Instanciates a new instance of the ${name} class.
+   * Instantiates a new instance of the ${name} class.
    * Initializes properties based on the provided model if it is an object.
    *
    * @param model - Optional partial model object to initialize the ${name}.


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This pull request makes minor documentation corrections to class constructors across several files. The main change is fixing the spelling of "Instanciates" to "Instantiates" in various docstrings.

* Documentation improvements:
  * Corrected the spelling of "Instanciates" to "Instantiates" in the docstrings for `ObjectHydrator`, `ArrayHydrator`, and generated class constructors in `src/lib/hydrator.ts` and `tools/4_generate-classes.ts`. [[1]](diffhunk://#diff-259277f1c4dbfcedfddd6bf38fd5ba4430caa15ea986b1ec0d7f99e4c693becaL25-R25) [[2]](diffhunk://#diff-259277f1c4dbfcedfddd6bf38fd5ba4430caa15ea986b1ec0d7f99e4c693becaL56-R56) [[3]](diffhunk://#diff-f6f870117d8c12e32ac48ea0a939c01ebe7744e88570ca61e82159db9158dbfdL81-R81)

**Special notes for reviewers**:

**Additional information (if needed):**
